### PR TITLE
Ensure consistent travel and movement bounds

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -28,7 +28,9 @@ def main() -> None:
             if last_move:
                 p.move(last_move, w)
         elif cmd.startswith('tra'):
-            p.travel(w)
+            parts = cmd.split()
+            year = int(parts[1]) if len(parts) > 1 else None
+            p.travel(w, year)
         elif cmd.startswith('exi'):
             persistence.save(p)
             break

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -22,15 +22,22 @@ class Player:
     def move(self, direction: str, world) -> bool:
         x, y = self.positions.setdefault(self.year, (0, 0))
         grid = world.year(self.year).grid
+        if direction not in {"north", "south", "east", "west"}:
+            print("can't go that way.")
+            return False
         neighbors = grid.neighbors(x, y)
         if direction in neighbors:
             self.positions[self.year] = neighbors[direction]
             return True
+        print("can't go that way.")
         return False
 
-    def travel(self, world) -> None:
-        """Switch between the two available years."""
-        self.year = 2100 if self.year == 2000 else 2000
+    def travel(self, world, target_year: int | None = None) -> None:
+        """Travel to ``target_year`` resetting position to origin."""
+        if target_year is None:
+            self.year = 2100 if self.year == 2000 else 2000
+        else:
+            self.year = target_year
         world.year(self.year)  # ensure world generation
-        self.positions.setdefault(self.year, (0, 0))
+        self.positions[self.year] = (0, 0)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import sys
+from pathlib import Path
+
+# Ensure the package root is importable when tests run from within the tests directory
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -2,10 +2,21 @@ from mutants2.engine.world import World
 from mutants2.engine.player import Player
 
 
-def test_player_movement():
+def test_player_movement(capsys):
     w = World()
     p = Player()
     assert p.move('north', w)
     assert (p.x, p.y) == (0, 1)
     assert not p.move('west', w)
+    out = capsys.readouterr().out
+    assert "can't go that way." in out
     assert (p.x, p.y) == (0, 1)
+
+
+def test_diagonal_rejected(capsys):
+    w = World()
+    p = Player()
+    assert not p.move('northwest', w)
+    out = capsys.readouterr().out
+    assert "can't go that way." in out
+    assert (p.x, p.y) == (0, 0)

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -14,4 +14,4 @@ def test_save_load(tmp_path, monkeypatch):
     p2 = persistence.load()
     assert (p2.year, p2.x, p2.y) == (2100, 0, 1)
     p2.travel(w)
-    assert (p2.x, p2.y) == (1, 0)
+    assert (p2.x, p2.y) == (0, 0)

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -9,12 +9,19 @@ def test_travel_and_positions():
     assert (p.x, p.y, p.year) == (1, 0, 2000)
 
     p.travel(w)
-    assert p.year == 2100
-    assert (p.x, p.y) == (0, 0)
+    assert (p.year, p.x, p.y) == (2100, 0, 0)
 
     assert p.move("north", w)
     assert (p.x, p.y) == (0, 1)
 
     p.travel(w)
-    assert (p.year, p.x, p.y) == (2000, 1, 0)
+    assert (p.year, p.x, p.y) == (2000, 0, 0)
+
+    assert p.move("east", w)
+    assert (p.x, p.y) == (1, 0)
+    p.travel(w, 2000)
+    assert (p.year, p.x, p.y) == (2000, 0, 0)
+
+    p.travel(w, 2100)
+    assert (p.year, p.x, p.y) == (2100, 0, 0)
 

--- a/tests/test_world_map.py
+++ b/tests/test_world_map.py
@@ -1,0 +1,14 @@
+from mutants2.engine.world import World
+
+
+def test_world_maps_have_origin_and_exits():
+    w = World()
+    for year in (2000, 2100, 2200):
+        grid = w.year(year).grid
+        assert grid.width == 30 and grid.height == 30
+        assert grid.is_walkable(0, 0)
+        assert grid.is_walkable(grid.width // 2, grid.height // 2)
+        neighbors = grid.neighbors(0, 0)
+        assert neighbors
+        for nx, ny in neighbors.values():
+            assert 0 <= nx < grid.width and 0 <= ny < grid.height


### PR DESCRIPTION
## Summary
- Restrict movement to N/S/E/W and print "can't go that way" when blocked
- Travel command can target a year and always returns the player to (0,0)
- Add world and movement tests for map bounds, diagonal rejection, and travel resets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b609a9878c832b899ce07beaa1909b