### PR TITLE
Add player class selection with persistence

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -1,9 +1,26 @@
 from ..engine import world, persistence, render
+from ..engine.player import CLASSES
+
+
+def class_menu(p):
+    while True:
+        print("Choose your class:")
+        for i, name in enumerate(CLASSES, 1):
+            print(f"{i}. {name}")
+        choice = input('class> ').strip().lower()
+        if choice == 'back':
+            break
+        if choice in {str(i) for i in range(1, len(CLASSES) + 1)}:
+            p.clazz = CLASSES[int(choice) - 1]
+            persistence.save(p)
+        else:
+            print("Choose 1-5 or 'back'.")
 
 
 def main() -> None:
     w = world.World()
     p = persistence.load()
+    class_menu(p)
     last_move = None
     while True:
         try:
@@ -31,9 +48,11 @@ def main() -> None:
             parts = cmd.split()
             year = int(parts[1]) if len(parts) > 1 else None
             p.travel(w, year)
+        elif cmd.startswith('cla'):
+            class_menu(p)
         elif cmd.startswith('exi'):
             persistence.save(p)
             break
         else:
-            print('Commands: look, north, south, east, west, last, travel, exit')
+            print('Commands: look, north, south, east, west, last, travel, class, exit')
         persistence.save(p)

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from typing import Dict, Tuple
 
-from .player import Player
+from .player import Player, CLASSES
 
 SAVE_PATH = Path(os.path.expanduser('~/.mutants2/save.json'))
 
@@ -17,7 +17,8 @@ def load() -> Player:
             int(k): (v.get("x", 0), v.get("y", 0))
             for k, v in data.get("positions", {}).items()
         }
-        player = Player(year=year)
+        clazz = data.get("class", CLASSES[0])
+        player = Player(year=year, clazz=clazz)
         player.positions.update(positions)
         return player
     except FileNotFoundError:
@@ -35,5 +36,6 @@ def save(player: Player) -> None:
                 str(y): {"x": x, "y": yy}
                 for y, (x, yy) in player.positions.items()
             },
+            "class": player.clazz,
         }
         json.dump(data, fh)

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -2,6 +2,11 @@ from dataclasses import dataclass, field
 from typing import Dict, Tuple
 
 
+# Available player classes. These are simple placeholders for now and do not
+# affect gameplay beyond being tracked and persisted.
+CLASSES = ["Warrior", "Mage", "Wizard", "Thief", "Priest"]
+
+
 @dataclass
 class Player:
     """Player state including position for each year."""
@@ -10,6 +15,7 @@ class Player:
     positions: Dict[int, Tuple[int, int]] = field(
         default_factory=lambda: {2000: (0, 0), 2100: (0, 0)}
     )
+    clazz: str = CLASSES[0]
 
     @property
     def x(self) -> int:

--- a/mutants2/engine/render.py
+++ b/mutants2/engine/render.py
@@ -4,6 +4,7 @@ from .player import Player
 
 def render(player: Player, world: World) -> None:
     print("---")
+    print(f"Class: {player.clazz}")
     print(f"{player.x}E : {player.y}N")
     grid = world.year(player.year).grid
     neighbors = grid.neighbors(player.x, player.y)

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -1,0 +1,34 @@
+import subprocess
+import sys
+
+from mutants2.engine import persistence
+
+
+def run_cli(inp, home):
+    cmd = [sys.executable, '-m', 'mutants2']
+    return subprocess.run(cmd, input=inp, text=True, capture_output=True, env={'HOME': str(home)})
+
+
+def test_default_class(tmp_path, monkeypatch):
+    monkeypatch.setenv('HOME', str(tmp_path))
+    player = persistence.load()
+    assert player.clazz == 'Warrior'
+    player2 = persistence.load()
+    assert player2.clazz == 'Warrior'
+
+
+def test_select_and_switch_class(tmp_path):
+    home = tmp_path
+    # First run: should default to Warrior
+    result = run_cli('back\nlook\nexit\n', home)
+    assert 'Class: Warrior' in result.stdout
+    # Choose Mage
+    run_cli('2\nback\nexit\n', home)
+    # Verify persisted Mage
+    result = run_cli('back\nlook\nexit\n', home)
+    assert 'Class: Mage' in result.stdout
+    # Switch to Thief
+    run_cli('4\nback\nexit\n', home)
+    # Verify persisted Thief
+    result = run_cli('back\nlook\nexit\n', home)
+    assert 'Class: Thief' in result.stdout

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,8 @@ import sys
 
 def test_cli_smoke(tmp_path):
     cmd = [sys.executable, '-m', 'mutants2']
-    inp = 'look\nnorth\nlast\ntravel\nlook\nexit\n'
+    # The game starts in the class menu; "back" leaves the menu to begin play.
+    inp = 'back\nlook\nnorth\nlast\ntravel\nlook\nexit\n'
     result = subprocess.run(cmd, input=inp, text=True, capture_output=True, env={'HOME': str(tmp_path)})
     assert result.returncode == 0
     assert 'On the ground lies' in result.stdout


### PR DESCRIPTION
## Summary
- introduce player class menu with five options and allow changing via `class`
- save and load chosen class alongside year and positions
- display current class in look header
- add tests for class persistence and switching

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b60b03703c832b82a6b19828ac81aa