### PR TITLE
Add dev-only senses cues plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ python -m mutants2
 ```bash
 pytest
 ```
+
+### Dev mode
+Set `MUTANTS2_DEV=1` or run `python -m mutants2 --dev` to enable `debug` commands:
+
+- `debug shadow <north|south|east|west>`
+- `debug footsteps <1..4>`
+- `debug clear`
+Cues are shown on the next `look` and then consumed.

--- a/mutants2/__main__.py
+++ b/mutants2/__main__.py
@@ -1,4 +1,16 @@
+import argparse
+import os
+
 from .cli.shell import main
 
+
+def _parse_args() -> bool:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dev", action="store_true", help="enable dev mode")
+    args = parser.parse_args()
+    return args.dev or os.environ.get("MUTANTS2_DEV") == "1"
+
+
 if __name__ == '__main__':
-    main()
+    dev_mode = _parse_args()
+    main(dev_mode=dev_mode)

--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -17,7 +17,7 @@ def class_menu(p):
             print("Choose 1-5 or 'back'.")
 
 
-def main() -> None:
+def main(*, dev_mode: bool = False) -> None:
     w = world.World()
     p = persistence.load()
     class_menu(p)
@@ -27,6 +27,30 @@ def main() -> None:
             cmd = input('> ').strip().lower()
         except EOFError:
             break
+        if cmd.startswith('debug'):
+            if not dev_mode:
+                print('Debug commands are available only in dev mode.')
+            else:
+                parts = cmd.split()
+                if len(parts) >= 2 and parts[1] == 'shadow' and len(parts) == 3:
+                    direction = parts[2]
+                    if direction in {'north', 'south', 'east', 'west'}:
+                        p.senses.add_shadow(direction)
+                        print('OK.')
+                    else:
+                        print('Invalid direction.')
+                elif len(parts) >= 2 and parts[1] == 'footsteps' and len(parts) == 3:
+                    try:
+                        p.senses.set_footsteps(int(parts[2]))
+                        print('OK.')
+                    except ValueError:
+                        print('footsteps distance must be 1..4')
+                elif len(parts) >= 2 and parts[1] == 'clear':
+                    p.senses.clear()
+                    print('OK.')
+                else:
+                    print('Invalid debug command.')
+            continue
         if cmd.startswith('loo'):
             render.render(p, w)
         elif cmd.startswith('nor'):

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -20,6 +20,7 @@ def load() -> Player:
         clazz = data.get("class", CLASSES[0])
         player = Player(year=year, clazz=clazz)
         player.positions.update(positions)
+        # Senses are ephemeral and intentionally not loaded
         return player
     except FileNotFoundError:
         player = Player()
@@ -37,5 +38,6 @@ def save(player: Player) -> None:
                 for y, (x, yy) in player.positions.items()
             },
             "class": player.clazz,
+            # no senses data; cues are never persisted
         }
         json.dump(data, fh)

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass, field
 from typing import Dict, Tuple
 
+from .senses import SensesBuffer
+
 
 # Available player classes. These are simple placeholders for now and do not
 # affect gameplay beyond being tracked and persisted.
@@ -16,6 +18,7 @@ class Player:
         default_factory=lambda: {2000: (0, 0), 2100: (0, 0)}
     )
     clazz: str = CLASSES[0]
+    senses: SensesBuffer = field(default_factory=SensesBuffer, repr=False)
 
     @property
     def x(self) -> int:

--- a/mutants2/engine/render.py
+++ b/mutants2/engine/render.py
@@ -1,8 +1,9 @@
 from .world import World
 from .player import Player
+from .senses import SensesCues
 
 
-def render(player: Player, world: World) -> None:
+def render(player: Player, world: World, *, consume_cues: bool = True) -> None:
     print("---")
     print(f"Class: {player.clazz}")
     print(f"{player.x}E : {player.y}N")
@@ -12,3 +13,13 @@ def render(player: Player, world: World) -> None:
         print(f"{direction} - open passage.")
     print("***")
     print("On the ground lies: ")
+    if consume_cues:
+        cues = player.senses.pop()
+    else:
+        cues = SensesCues()
+    for d in ("north", "south", "east", "west"):
+        if d in cues.shadow_dirs:
+            print(f"A shadow flickers to the {d}.")
+    if cues.footsteps_distance:
+        mapping = {1: "very close", 2: "close", 3: "nearby", 4: "far away"}
+        print(f"You hear footsteps {mapping[cues.footsteps_distance]}.")

--- a/mutants2/engine/senses.py
+++ b/mutants2/engine/senses.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass, field
+from typing import Optional, Set, Literal
+
+Direction = Literal["north", "south", "east", "west"]
+
+
+@dataclass
+class SensesCues:
+    shadow_dirs: Set[Direction] = field(default_factory=set)
+    footsteps_distance: Optional[int] = None
+
+    def clear(self) -> None:
+        self.shadow_dirs.clear()
+        self.footsteps_distance = None
+
+
+@dataclass
+class SensesBuffer:
+    """Ephemeral buffer; consumed on `look`."""
+
+    _cues: SensesCues = field(default_factory=SensesCues)
+
+    def add_shadow(self, direction: Direction) -> None:
+        self._cues.shadow_dirs.add(direction)
+
+    def set_footsteps(self, distance: int) -> None:
+        if distance < 1 or distance > 4:
+            raise ValueError("footsteps distance must be 1..4")
+        self._cues.footsteps_distance = distance
+
+    def clear(self) -> None:
+        self._cues.clear()
+
+    def pop(self) -> SensesCues:
+        current = SensesCues(
+            shadow_dirs=set(self._cues.shadow_dirs),
+            footsteps_distance=self._cues.footsteps_distance,
+        )
+        self._cues.clear()
+        return current

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Tuple, Set
 
-
-Direction = str
+from .senses import Direction
 Coordinate = Tuple[int, int]
 
 

--- a/tests/test_senses_dev.py
+++ b/tests/test_senses_dev.py
@@ -1,0 +1,65 @@
+import os
+
+import pytest
+
+
+def enable_dev_env():
+    os.environ["MUTANTS2_DEV"] = "1"
+
+
+@pytest.fixture
+def cli_runner(tmp_path):
+    import subprocess, sys
+
+    class Runner:
+        def run_commands(self, commands):
+            cmd = [sys.executable, "-m", "mutants2"]
+            env = os.environ.copy()
+            env.setdefault("HOME", str(tmp_path))
+            inp = "back\n" + "\n".join(commands + ["exit"]) + "\n"
+            result = subprocess.run(cmd, input=inp, text=True, capture_output=True, env=env)
+            return result.stdout
+
+    return Runner()
+
+
+def test_debug_commands_rejected_without_dev(cli_runner):
+    os.environ.pop("MUTANTS2_DEV", None)
+    out = cli_runner.run_commands(["debug shadow north", "look"])
+    assert "Debug commands are available only in dev mode." in out
+
+
+def test_shadow_and_footsteps_render_once(cli_runner):
+    enable_dev_env()
+    out = cli_runner.run_commands([
+        "debug clear",
+        "debug shadow north",
+        "debug shadow east",
+        "debug footsteps 3",
+        "look",
+        "look",
+    ])
+    assert "A shadow flickers to the north." in out
+    assert "A shadow flickers to the east." in out
+    assert "You hear footsteps nearby." in out
+    parts = out.split("On the ground lies:")
+    assert len(parts) >= 3
+    seg = parts[2]
+    assert "A shadow flickers" not in seg
+    assert "footsteps" not in seg
+
+
+def test_invalid_footsteps_distance(cli_runner):
+    enable_dev_env()
+    out = cli_runner.run_commands(["debug footsteps 0"])
+    assert "must be 1..4" in out or "Invalid" in out
+
+
+def test_debug_clear(cli_runner):
+    enable_dev_env()
+    out = cli_runner.run_commands([
+        "debug shadow south",
+        "debug clear",
+        "look",
+    ])
+    assert "A shadow flickers" not in out


### PR DESCRIPTION
## Summary
- Implement ephemeral sensing system with shadow and footsteps cues
- Gate new `debug` commands behind `--dev` flag or `MUTANTS2_DEV` env
- Render and consume cues on `look`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b60da7aeac832b9aa5167e8c04b564