### PR TITLE
In-game macros with profiles and help

### DIFF
--- a/mutants2/__main__.py
+++ b/mutants2/__main__.py
@@ -26,13 +26,15 @@ except Exception:  # pragma: no cover - best-effort only
     pass
 
 
-def _parse_args() -> bool:
+def _parse_args() -> tuple[bool, str | None]:
     parser = argparse.ArgumentParser()
     parser.add_argument("--dev", action="store_true", help="enable dev mode")
+    parser.add_argument("--macro-profile", help="load macro profile on start")
     args = parser.parse_args()
-    return args.dev or os.environ.get("MUTANTS2_DEV") == "1"
+    dev = args.dev or os.environ.get("MUTANTS2_DEV") == "1"
+    return dev, args.macro_profile
 
 
 if __name__ == '__main__':
-    dev_mode = _parse_args()
-    main(dev_mode=dev_mode)
+    dev_mode, macro_profile = _parse_args()
+    main(dev_mode=dev_mode, macro_profile=macro_profile)

--- a/mutants2/engine/macros.py
+++ b/mutants2/engine/macros.py
@@ -1,0 +1,176 @@
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Callable, List
+
+
+class MacroError(Exception):
+    """Raised for macro parsing or execution errors."""
+
+
+class MacroStore:
+    """Store and execute command macros."""
+
+    MACRO_DIR = Path(os.path.expanduser("~/.mutants2/macros"))
+
+    def __init__(self) -> None:
+        self._macros: dict[str, str] = {}
+        self.echo: bool = True
+        self._call_depth: int = 0
+
+    # basic management -------------------------------------------------
+    def add(self, name: str, script: str) -> None:
+        self._macros[name] = script
+
+    def get(self, name: str) -> str:
+        return self._macros[name]
+
+    def remove(self, name: str) -> None:
+        self._macros.pop(name, None)
+
+    def list(self) -> List[str]:
+        return sorted(self._macros)
+
+    def clear(self) -> None:
+        self._macros.clear()
+
+    # profile IO -------------------------------------------------------
+    def save_profile(self, profile: str) -> None:
+        self.MACRO_DIR.mkdir(parents=True, exist_ok=True)
+        path = self.MACRO_DIR / f"{profile}.json"
+        data = {"macros": self._macros, "echo": self.echo}
+        with path.open("w", encoding="utf-8") as f:
+            json.dump(data, f)
+
+    def load_profile(self, profile: str) -> None:
+        path = self.MACRO_DIR / f"{profile}.json"
+        with path.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        self._macros.update(data.get("macros", {}))
+        if "echo" in data:
+            self.echo = data["echo"]
+
+    def list_profiles(self) -> List[str]:
+        if not self.MACRO_DIR.is_dir():
+            return []
+        return sorted(p.stem for p in self.MACRO_DIR.glob("*.json"))
+
+    # expansion --------------------------------------------------------
+    def _substitute(self, script: str, args: List[str]) -> str:
+        mapping = {str(i + 1): arg for i, arg in enumerate(args)}
+        mapping["*"] = " ".join(args)
+
+        def repl(m: re.Match) -> str:
+            key = m.group(1)
+            return mapping.get(key, "")
+
+        return re.sub(r"\$(\d+|\*)", repl, script)
+
+    def _tokenize(self, script: str) -> List[str]:
+        tokens: List[str] = []
+        cur = []
+        level = 0
+        i = 0
+        while i < len(script):
+            ch = script[i]
+            if ch == "#":
+                while i < len(script) and script[i] != "\n":
+                    i += 1
+                continue
+            if ch in ";\n" and level == 0:
+                token = "".join(cur).strip()
+                if token:
+                    tokens.append(token)
+                cur = []
+            else:
+                if ch == "(":
+                    level += 1
+                elif ch == ")" and level > 0:
+                    level -= 1
+                cur.append(ch)
+            i += 1
+        token = "".join(cur).strip()
+        if token:
+            tokens.append(token)
+        return tokens
+
+    def expand(self, script: str, args: List[str]) -> List[str]:
+        substituted = self._substitute(script, args)
+        result: List[str] = []
+        step_counter = 0
+
+        def add(cmd: str) -> None:
+            nonlocal step_counter
+            step_counter += 1
+            if step_counter > 1000:
+                raise MacroError("macro expansion exceeded step limit")
+            result.append(cmd)
+
+        def _expand(text: str, depth: int) -> None:
+            if depth > 8:
+                raise MacroError("macro recursion too deep")
+            for tok in self._tokenize(text):
+                m = re.fullmatch(r"\((.*)\)\*(\d+)", tok, re.S)
+                if m:
+                    inner, count = m.group(1), int(m.group(2))
+                    for _ in range(count):
+                        _expand(inner, depth + 1)
+                    continue
+                m = re.fullmatch(r"([^()\s]+)\*(\d+)", tok)
+                if m:
+                    cmd, count = m.group(1), int(m.group(2))
+                    for _ in range(count):
+                        add(cmd)
+                    continue
+                if re.fullmatch(r"(\d*[nsew])+", tok, re.I):
+                    for part in re.finditer(r"(\d*)([nsew])", tok, re.I):
+                        num = int(part.group(1) or "1")
+                        dirc = part.group(2).lower()
+                        for _ in range(num):
+                            add(dirc)
+                    continue
+                add(tok)
+
+        _expand(substituted, 0)
+        return result
+
+    # execution --------------------------------------------------------
+    def run(self, script: str, args: List[str], dispatch: Callable[[str], bool]) -> None:
+        try:
+            cmds = self.expand(script, args)
+        except MacroError as e:
+            print(f"Macro error: {e}")
+            return
+        if self._call_depth >= 8:
+            print("Macro recursion too deep")
+            return
+        self._call_depth += 1
+        try:
+            for cmd in cmds:
+                if self.echo:
+                    print(f"> {cmd}")
+                if cmd.lower().startswith("wait "):
+                    try:
+                        ms = int(cmd.split()[1])
+                    except Exception:
+                        print("Invalid wait")
+                        break
+                    ms = min(ms, 2000)
+                    time.sleep(ms / 1000.0)
+                    continue
+                if not dispatch(cmd):
+                    break
+        finally:
+            self._call_depth -= 1
+
+    def run_named(self, name: str, args: List[str], dispatch: Callable[[str], bool]) -> None:
+        script = self._macros.get(name)
+        if script is None:
+            print("No such macro")
+            return
+        self.run(script, args, dispatch)
+
+    def run_script(self, script: str, dispatch: Callable[[str], bool]) -> None:
+        self.run(script, [], dispatch)

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -1,0 +1,50 @@
+MACROS_HELP = """\
+MACROS — define/run/edit command macros, with profiles
+=====================================================
+
+Basics
+------
+  macro add <name> = <script>      Define/replace a macro
+  macro run <name> [args…]         Run a stored macro
+  @<name> [args…]                  Quick-run (shorthand for macro run)
+  do <script>                      Run a one-off script (not stored)
+  macro list | show <name>         List names or show a script
+  macro rm <name> | macro clear    Remove one or all macros (clear asks to confirm)
+  macro echo on|off                Toggle echo of expanded commands (default: on)
+
+Profiles (saved outside the savegame)
+-------------------------------------
+  macro save <profile>             Save to ~/.mutants2/macros/<profile>.json
+  macro load <profile>             Load/merge from that file (overwrites same-name)
+  macro profiles                   List available profiles
+  Startup (optional):              Auto-load ~/.mutants2/macros/default.json if present
+
+Script language
+---------------
+  • Separator:      Use ';' (newlines also act as ';')
+  • Parameters:     $1 $2 ... $*  (all remaining words)
+       e.g.,  macro add getn = get $*; north; look
+  • Repeat single:  cmd*3          → cmd; cmd; cmd
+  • Repeat group:   (cmd1; cmd2)*N → cmd1; cmd2; ... (N times)
+  • Speed-walk:     tokens like 3n2e4w → n;n;n;e;e;w;w;w;w
+       (valid dirs: n s e w; case-insensitive)
+  • Wait:           wait <ms>      Pause for ms (capped at 2000)
+  • Comments:       '#' to end of line is ignored
+
+Safety & limits
+---------------
+  • No deep recursion: calls limited to depth ≤ 8
+  • Expansion cap:    ≤ 1000 subcommands per run
+  • On unknown subcommand or limit breach: stop with a clear error
+  • Echo: when on, each expanded command prints as '> <cmd>'
+
+Examples
+--------
+  macro add scout = look; n*2; look; e; look; (w; s)*2
+  @scout
+
+  macro add farm = (look; wait 150; get $1; wait 150)*5
+  macro run farm Ion-Decay
+
+  do 7e3n; look
+"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,24 @@
+import os
 import sys
 from pathlib import Path
 
+import pytest
+
 # Ensure the package root is importable when tests run from within the tests directory
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+@pytest.fixture
+def cli_runner(tmp_path):
+    import subprocess
+
+    class Runner:
+        def run_commands(self, commands):
+            cmd = [sys.executable, "-m", "mutants2"]
+            env = os.environ.copy()
+            env.setdefault("HOME", str(tmp_path))
+            inp = "1\n" + "\n".join(commands + ["exit"]) + "\n"
+            result = subprocess.run(cmd, input=inp, text=True, capture_output=True, env=env)
+            return result.stdout
+
+    return Runner()

--- a/tests/test_macros.py
+++ b/tests/test_macros.py
@@ -1,0 +1,65 @@
+import re
+
+
+def test_add_run_basic(cli_runner):
+    out = cli_runner.run_commands([
+        "macro add scout = look; n*2; look",
+        "@scout",
+    ])
+    assert out.count("> look") >= 2
+    assert "> n" in out
+
+
+def test_parameters_and_do(cli_runner):
+    out = cli_runner.run_commands([
+        "macro add getn = get $*; north; look",
+        "macro run getn Ion-Decay",
+        "do (east; look)*2",
+    ])
+    assert "> get Ion-Decay" in out
+    assert out.count("> east") >= 2
+
+
+def test_speedwalk(cli_runner):
+    out = cli_runner.run_commands([
+        "do 3n2e",
+    ])
+    assert out.count("> n") == 3
+    assert out.count("> e") == 2
+
+
+def test_repeat_limits(cli_runner):
+    out = cli_runner.run_commands(["do (look)*1001"])
+    assert "step limit" in out.lower()
+
+
+def test_profiles_save_load(cli_runner):
+    out = cli_runner.run_commands([
+        "macro add a = look",
+        "macro save test1",
+        "macro clear",
+        "yes",
+        "macro load test1",
+        "@a",
+        "macro profiles",
+    ])
+    assert "> look" in out
+    assert "test1" in out
+
+
+def test_echo_toggle(cli_runner):
+    out = cli_runner.run_commands([
+        "macro add a = look",
+        "@a",
+        "macro echo off",
+        "@a",
+        "macro echo on",
+        "@a",
+    ])
+    assert out.count("> look") == 2
+
+
+def test_wait_caps(cli_runner):
+    out = cli_runner.run_commands(["do wait 5000; look"])
+    assert "> wait 5000" in out
+    assert "> look" in out

--- a/tests/test_macros_help.py
+++ b/tests/test_macros_help.py
@@ -1,0 +1,12 @@
+from mutants2.ui.help import MACROS_HELP
+
+
+def test_help_macros_contains_key_sections(cli_runner):
+    out = cli_runner.run_commands(["help macros"])
+    assert "MACROS — define/run/edit" in out
+    assert "macro add <name> = <script>" in out
+    assert "Profiles (saved outside the savegame)" in out
+    assert "Script language" in out
+    assert "Speed-walk" in out
+    assert "Safety & limits" in out
+    assert "Examples" in out


### PR DESCRIPTION
## Summary
- Add MacroStore supporting scripts, repeats, speed-walk, wait and profile persistence
- Integrate macros into shell with @quick-run, do, and profile commands
- Document macros via `help macros` page and add tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6205d79f0832b99b054bb0bbb70d9