### PR TITLE
Enable single-key line fallback for macro bindings

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -24,6 +24,28 @@ DIRECTION_ALIASES = {
 }
 
 
+def is_single_key(s: str) -> bool:
+    s = s.lower()
+    if len(s) == 1:
+        return True
+    if s.startswith("f") and s[1:].isdigit():
+        i = int(s[1:])
+        return 1 <= i <= 12
+    return s in {
+        "up",
+        "down",
+        "left",
+        "right",
+        "home",
+        "end",
+        "pageup",
+        "pagedown",
+        "tab",
+        "escape",
+        "space",
+    }
+
+
 def class_menu(p, w, *, in_game: bool) -> bool:
     """Show the class selection menu.
 
@@ -82,7 +104,8 @@ def main(*, dev_mode: bool = False, macro_profile: str | None = None) -> None:
 
     def dispatch(line: str) -> bool:
         nonlocal last_move, running
-        parts = line.strip().split()
+        s = line.strip()
+        parts = s.split()
         if not parts:
             return True
         cmd = parts[0].lower()
@@ -182,6 +205,11 @@ def main(*, dev_mode: bool = False, macro_profile: str | None = None) -> None:
             running = False
             return False
         else:
+            if macro_store.keys_enabled and is_single_key(s):
+                script = resolve_bound_script(macro_store, s.lower())
+                if script:
+                    macro_store.expand_and_run_script(script, dispatch)
+                    return True
             print("Unknown command.")
             return False
         persistence.save(p, w)

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -26,6 +26,8 @@ Key bindings
     • Bindings fire on single keypress when the line is empty.
     • In many terminals, keypad digits behave like top-row digits. Binding kp4 will also
       trigger on 4 when the line is empty.
+    • If your terminal doesn't support single-keypress interception, type the key and
+      press Enter (e.g., 4 then Enter for kp4).
 
 
 Profiles (saved outside the savegame)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ def cli_runner(tmp_path):
         def run_commands(self, commands):
             cmd = [sys.executable, "-m", "mutants2"]
             env = os.environ.copy()
-            env.setdefault("HOME", str(tmp_path))
+            env["HOME"] = str(tmp_path)
             inp = "1\n" + "\n".join(commands + ["exit"]) + "\n"
             result = subprocess.run(cmd, input=inp, text=True, capture_output=True, env=env)
             return result.stdout

--- a/tests/test_macros_keys_fallback.py
+++ b/tests/test_macros_keys_fallback.py
@@ -1,0 +1,32 @@
+def test_char_binding_via_line_fallback(cli_runner):
+    out = cli_runner.run_commands([
+        "macro bind z = look",
+        "z",
+    ])
+    assert "***" in out and "Class:" in out
+
+
+def test_kp_binding_triggers_with_digit(cli_runner):
+    out = cli_runner.run_commands([
+        "macro bind kp4 = west",
+        "4",
+        "look",
+    ])
+    assert "Unknown command" not in out
+
+
+def test_builtin_precedence(cli_runner):
+    out = cli_runner.run_commands([
+        "macro bind n = look",
+        "n",
+    ])
+    assert "Unknown command" not in out
+
+
+def test_keys_off_disables_fallback(cli_runner):
+    out = cli_runner.run_commands([
+        "macro bind z = look",
+        "macro keys off",
+        "z",
+    ])
+    assert "Unknown command" in out


### PR DESCRIPTION
## Summary
- run bound macros when a single key + Enter is submitted
- document Enter-based fallback in macros help
- add tests for keybinding fallback and fix CLI runner HOME isolation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b62d2b0bac832b8cc2658717e4a7d8