### PR TITLE
feat: add prompt-toolkit REPL with instant keybindings

### DIFF
--- a/mutants2/cli/repl.py
+++ b/mutants2/cli/repl.py
@@ -1,0 +1,89 @@
+from mutants2.engine.macros import resolve_bound_script
+
+
+class FallbackRepl:
+    def __init__(self, context) -> None:
+        self.ctx = context
+        self.ctx.macro_store.repl_mode = "Fallback"
+
+    def run(self) -> None:
+        while True:
+            try:
+                line = input("> ")
+            except (EOFError, KeyboardInterrupt):
+                print("")
+                break
+            self.ctx.dispatch_line(line)
+
+
+class PtkRepl:
+    def __init__(self, context) -> None:
+        self.ctx = context
+        from prompt_toolkit import PromptSession
+        from prompt_toolkit.key_binding import KeyBindings
+
+        self.PromptSession = PromptSession
+        self.KeyBindings = KeyBindings
+        self.ctx.macro_store.repl_mode = "PTK"
+
+    def run(self) -> None:
+        kb = self.KeyBindings()
+        session = self.PromptSession(key_bindings=kb, enable_history_search=True)
+        store = self.ctx.macro_store
+
+        def debug(msg: str) -> None:
+            if getattr(store, "keys_debug", False):
+                print(msg)
+
+        def try_fire(event, key_id: str | None, ch: str | None) -> bool:
+            buf = event.app.current_buffer
+            if not store.keys_enabled or buf.text:
+                return False
+            key_display = key_id or ch or "?"
+            script = resolve_bound_script(store, key_id) if key_id else None
+            if not script and ch:
+                script = resolve_bound_script(store, ch)
+            debug(f"[#] key='{key_display}' data='{ch or ''}' → resolved={'yes' if script else 'no'}")
+            if not script:
+                return False
+            event.prevent_default()
+            buf.reset()
+            self.ctx.run_script(script)
+            return True
+
+        @kb.add("<any>")
+        def _(event):
+            ch = event.data
+            if ch and try_fire(event, None, ch):
+                return
+            # otherwise let PTK handle normally
+
+        names = [
+            "up",
+            "down",
+            "left",
+            "right",
+            "home",
+            "end",
+            "pageup",
+            "pagedown",
+            "tab",
+            "escape",
+            "space",
+        ] + [f"f{i}" for i in range(1, 13)]
+
+        for name in names:
+            try:
+                @kb.add(name)
+                def _(event, _n=name):
+                    try_fire(event, _n, None)
+            except Exception:
+                pass
+
+        while True:
+            try:
+                line = session.prompt("> ")
+            except (EOFError, KeyboardInterrupt):
+                print("")
+                break
+            self.ctx.dispatch_line(line)

--- a/mutants2/engine/macros.py
+++ b/mutants2/engine/macros.py
@@ -35,6 +35,8 @@ class MacroStore:
         self.echo: bool = True
         self._call_depth: int = 0
         self.keys_enabled: bool = True
+        self.keys_debug: bool = False
+        self.repl_mode: str = "Fallback"
         self._bindings: dict[str, str] = {}
 
     # basic management -------------------------------------------------

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -23,7 +23,8 @@ Key bindings
   Keypad aliases: kp0..kp9, kp_plus, kp_minus, kp_mul, kp_div, kp_enter, kp_dot (fallback to top-row if indistinguishable)
 
   Behavior:
-    • Bindings fire on single keypress when the line is empty.
+    • Bindings fire on single keypress when the line is empty. Use `macro keys debug on` to
+      print the key names seen by the shell.
     • In many terminals, keypad digits behave like top-row digits. Binding kp4 will also
       trigger on 4 when the line is empty.
     • If your terminal doesn't support single-keypress interception, type the key and

--- a/tests/test_keymap.py
+++ b/tests/test_keymap.py
@@ -1,0 +1,14 @@
+from mutants2.cli.keynames import normalize_key
+from mutants2.engine.macros import MacroStore, resolve_bound_script
+
+
+def test_normalize_key_aliases():
+    assert normalize_key("kp4") == "kp4"
+    assert normalize_key("F5") == "f5"
+    assert normalize_key("z") == "z"
+
+
+def test_keypad_fallback_resolve():
+    store = MacroStore()
+    store.bind("kp4", "look")
+    assert resolve_bound_script(store, "4") == "look"


### PR DESCRIPTION
## Summary
- add prompt_toolkit-powered REPL that fires macros on single keypress and supports key debug output
- extend macro command with key debug/status and choose REPL via `--ptk`/`--no-ptk`
- document instant keypress behaviour and test key normalisation and keypad fallback

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6301f102c832baaea9c9560fba491