### PR TITLE
Enable prompt_toolkit REPL with diagnostics

### DIFF
--- a/mutants2/__main__.py
+++ b/mutants2/__main__.py
@@ -1,15 +1,5 @@
-import argparse
 import os
 import atexit
-import sys
-
-from .cli.shell import main
-
-# Try to enable prompt_toolkit for richer key handling if available.
-try:  # pragma: no cover
-    import prompt_toolkit  # noqa: F401
-except Exception:  # pragma: no cover
-    prompt_toolkit = None
 
 # Enable command history and line editing if ``readline`` is available. The
 # history is persisted across sessions in ``~/.mutants2/history``. Importing
@@ -32,32 +22,7 @@ try:  # pragma: no cover - behaviour depends on platform availability
 except Exception:  # pragma: no cover - best-effort only
     pass
 
+from .main import main
 
-def _parse_args() -> tuple[bool, str | None, bool, bool]:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--dev", action="store_true", help="enable dev mode")
-    parser.add_argument("--macro-profile", help="load macro profile on start")
-    parser.add_argument("--ptk", action="store_true", help="force prompt_toolkit mode")
-    parser.add_argument("--no-ptk", action="store_true", help="disable prompt_toolkit")
-    args = parser.parse_args()
-    dev = args.dev or os.environ.get("MUTANTS2_DEV") == "1"
-    no_ptk = args.no_ptk or os.environ.get("MUTANTS2_NO_PTK") == "1"
-    return dev, args.macro_profile, args.ptk, no_ptk
-
-
-if __name__ == '__main__':
-    dev_mode, macro_profile, force_ptk, no_ptk = _parse_args()
-    if force_ptk and no_ptk:
-        print("Cannot use both --ptk and --no-ptk")
-        sys.exit(1)
-    use_ptk = False
-    if force_ptk:
-        if prompt_toolkit is None:
-            print("prompt_toolkit is required but not installed")
-            sys.exit(1)
-        use_ptk = True
-    elif no_ptk:
-        use_ptk = False
-    else:
-        use_ptk = prompt_toolkit is not None and sys.stdin.isatty()
-    main(dev_mode=dev_mode, macro_profile=macro_profile, use_ptk=use_ptk)
+if __name__ == "__main__":
+    main()

--- a/mutants2/main.py
+++ b/mutants2/main.py
@@ -1,0 +1,64 @@
+import argparse
+import os
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class ReplChoice:
+    mode: str
+    reason: str | None
+
+
+def choose_repl(force: str | None) -> ReplChoice:
+    if force == "fallback" or os.getenv("MUTANTS2_NO_PTK") == "1":
+        return ReplChoice("Fallback", "forced_fallback")
+    try:
+        import prompt_toolkit  # noqa: F401
+    except Exception as e:  # pragma: no cover
+        return ReplChoice("Fallback", f"import_error: {e.__class__.__name__}")
+    if force == "ptk":
+        return ReplChoice("PTK", None)
+    return ReplChoice("PTK", None) if sys.stdin.isatty() else ReplChoice("Fallback", "not_tty")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dev", action="store_true")
+    parser.add_argument("--macro-profile")
+    parser.add_argument("--ptk", action="store_true")
+    parser.add_argument("--no-ptk", action="store_true")
+    args = parser.parse_args()
+
+    dev = args.dev or os.environ.get("MUTANTS2_DEV") == "1"
+    if args.ptk and args.no_ptk:
+        print("Cannot use both --ptk and --no-ptk")
+        sys.exit(1)
+
+    force = "ptk" if args.ptk else ("fallback" if args.no_ptk else None)
+    choice = choose_repl(force)
+    if args.ptk and choice.mode != "PTK":
+        print(f"prompt_toolkit unavailable ({choice.reason})")
+        sys.exit(1)
+
+    from mutants2.cli.shell import make_context
+
+    ctx = make_context(
+        dev=dev,
+        macro_profile=args.macro_profile,
+        repl_mode=choice.mode,
+        repl_reason=choice.reason,
+    )
+
+    if choice.mode == "PTK":
+        from mutants2.cli.repl import PtkRepl
+
+        PtkRepl(ctx).run()
+    else:
+        from mutants2.cli.repl import FallbackRepl
+
+        FallbackRepl(ctx).run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_macros_keypad.py
+++ b/tests/test_macros_keypad.py
@@ -1,0 +1,6 @@
+def test_digit_resolves_to_keypad_alias():
+    from mutants2.engine.macros import MacroStore, resolve_bound_script
+
+    store = MacroStore()
+    store.bind("kp4", "west")
+    assert resolve_bound_script(store, "4") == "west"


### PR DESCRIPTION
## Summary
- add REPL chooser with prompt_toolkit default and explicit reasons for fallback
- refactor shell context to expose REPL mode diagnostics
- implement prompt_toolkit REPL with instant macro key dispatch
- test keypad digit fallback to keypad alias

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b632a29adc832ba73cd20e87a6e5c7