### PR TITLE
Fix prompt-toolkit key handling and preserve exit

### DIFF
--- a/mutants2/cli/repl.py
+++ b/mutants2/cli/repl.py
@@ -12,7 +12,8 @@ class FallbackRepl:
             except (EOFError, KeyboardInterrupt):
                 print("")
                 break
-            self.ctx.dispatch_line(line)
+            if self.ctx.dispatch_line(line):
+                break
 
 
 class PtkRepl:
@@ -20,42 +21,41 @@ class PtkRepl:
         self.ctx = context
         from prompt_toolkit import PromptSession
         from prompt_toolkit.key_binding import KeyBindings
-        from prompt_toolkit.keys import Keys
 
         self.PromptSession = PromptSession
         self.KeyBindings = KeyBindings
-        self.Keys = Keys
 
     def run(self) -> None:
         kb = self.KeyBindings()
         session = self.PromptSession(key_bindings=kb, enable_history_search=True)
         store = self.ctx.macro_store
 
-        def dbg(msg: str) -> None:
-            if getattr(store, "keys_debug", False):
-                print(msg)
+        from prompt_toolkit.keys import Keys
 
-        def try_fire(event, key_id: str | None, ch: str | None) -> bool:
-            buf = event.app.current_buffer
-            if not store.keys_enabled or buf.text:
-                return False
-            key_disp = key_id or ch or "?"
-            script = resolve_bound_script(store, key_id) if key_id else None
-            if not script and ch:
-                script = resolve_bound_script(store, ch)
-            dbg(f"[#] key='{key_disp}' data='{ch or ''}' -> {'hit' if script else 'miss'}")
-            if not script:
-                return False
-            event.prevent_default()
-            buf.reset()
-            self.ctx.run_script(script)
-            return True
-
-        @kb.add(self.Keys.Any)
+        @kb.add(Keys.Any)
         def _(event):
+            """
+            For printable keys: only intercept when a real binding will fire.
+            Otherwise, insert the typed character so normal typing works.
+            """
+            buf = event.app.current_buffer
             ch = event.data  # '' for non-printables
-            if ch and try_fire(event, None, ch):
-                return  # consumed
+
+            # Try to fire ONLY when: keys enabled, line empty, and printable char
+            if ch and not buf.text and store.keys_enabled:
+                script = resolve_bound_script(store, ch)
+                if getattr(store, "keys_debug", False):
+                    print(f"[#] any key='{ch}' -> {'hit' if bool(script) else 'miss'}")
+
+                if script:
+                    event.prevent_default()
+                    buf.reset()
+                    self.ctx.run_script(script)
+                    return
+
+            # Not handled -> INSERT the character so typing works
+            if ch:
+                event.app.current_buffer.insert_text(ch)
 
         names = [
             "up",
@@ -75,7 +75,16 @@ class PtkRepl:
             try:
                 @kb.add(name)
                 def _(event, _n=name):
-                    try_fire(event, _n, None)
+                    buf = event.app.current_buffer
+                    if not store.keys_enabled or buf.text:
+                        return  # do not intercept; let default behavior occur
+                    script = resolve_bound_script(store, _n)
+                    if getattr(store, "keys_debug", False):
+                        print(f"[#] named key='{_n}' -> {'hit' if bool(script) else 'miss'}")
+                    if script:
+                        event.prevent_default()
+                        buf.reset()
+                        self.ctx.run_script(script)
             except Exception:
                 pass
 
@@ -85,4 +94,5 @@ class PtkRepl:
             except (EOFError, KeyboardInterrupt):
                 print("")
                 break
-            self.ctx.dispatch_line(line)
+            if self.ctx.dispatch_line(line):
+                break

--- a/tests/test_exit_priority.py
+++ b/tests/test_exit_priority.py
@@ -1,0 +1,9 @@
+from mutants2.cli.shell import make_context
+
+
+def test_exit_priority(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr("builtins.input", lambda *_: "1")
+    ctx = make_context()
+    ctx.macro_store.bind("e", "look")
+    assert ctx.dispatch_line("exit") is True

--- a/tests/test_macros_keys_fallback.py
+++ b/tests/test_macros_keys_fallback.py
@@ -30,3 +30,12 @@ def test_keys_off_disables_fallback(cli_runner):
         "z",
     ])
     assert "Unknown command" in out
+
+
+def test_keys_panic_disables_fallback(cli_runner):
+    out = cli_runner.run_commands([
+        "macro bind z = look",
+        "macro keys panic",
+        "z",
+    ])
+    assert "Unknown command" in out


### PR DESCRIPTION
## Summary
- ensure PTK `<any>` and named keys insert characters unless a binding fires
- have dispatch loop return True on `exit` and add `macro keys panic`
- add regression tests for exit priority and key panic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b636740e1c832bb7a419b6253c3f4b