### PR TITLE
Fix PTK key handler for prompt_toolkit 3

### DIFF
--- a/mutants2/cli/repl.py
+++ b/mutants2/cli/repl.py
@@ -28,65 +28,32 @@ class PtkRepl:
     def run(self) -> None:
         kb = self.KeyBindings()
         session = self.PromptSession(key_bindings=kb, enable_history_search=True)
-        store = self.ctx.macro_store
 
         from prompt_toolkit.keys import Keys
 
-        @kb.add(Keys.Any)
+        @kb.add(Keys.Any, eager=True)
         def _(event):
-            """
-            For printable keys: only intercept when a real binding will fire.
-            Otherwise, insert the typed character so normal typing works.
-            """
+            """Printable keys: fire a macro only when the line is empty and a binding exists.
+            Otherwise, insert the typed character so normal typing works."""
+            store = self.ctx.macro_store
             buf = event.app.current_buffer
-            ch = event.data  # '' for non-printables
+            ch = event.data  # printable char or '' for non-printables
 
-            # Try to fire ONLY when: keys enabled, line empty, and printable char
-            if ch and not buf.text and store.keys_enabled:
+            if ch and store.keys_enabled and not buf.text:
                 script = resolve_bound_script(store, ch)
                 if getattr(store, "keys_debug", False):
-                    print(f"[#] any key='{ch}' -> {'hit' if bool(script) else 'miss'}")
+                    print(f"[#] key='{ch}' -> {'hit' if bool(script) else 'miss'}")
 
                 if script:
-                    event.prevent_default()
+                    # No prevent_default in PTK 3.x. Because this handler is eager,
+                    # default insertion won’t run; we just clear the line and execute.
                     buf.reset()
-                    self.ctx.run_script(script)
+                    self.ctx.run_script(script)   # expand + dispatch each subcommand
                     return
 
-            # Not handled -> INSERT the character so typing works
+            # Not handled: insert the character so normal typing works.
             if ch:
-                event.app.current_buffer.insert_text(ch)
-
-        names = [
-            "up",
-            "down",
-            "left",
-            "right",
-            "home",
-            "end",
-            "pageup",
-            "pagedown",
-            "tab",
-            "escape",
-            "space",
-        ] + [f"f{i}" for i in range(1, 13)]
-
-        for name in names:
-            try:
-                @kb.add(name)
-                def _(event, _n=name):
-                    buf = event.app.current_buffer
-                    if not store.keys_enabled or buf.text:
-                        return  # do not intercept; let default behavior occur
-                    script = resolve_bound_script(store, _n)
-                    if getattr(store, "keys_debug", False):
-                        print(f"[#] named key='{_n}' -> {'hit' if bool(script) else 'miss'}")
-                    if script:
-                        event.prevent_default()
-                        buf.reset()
-                        self.ctx.run_script(script)
-            except Exception:
-                pass
+                buf.insert_text(ch)
 
         while True:
             try:


### PR DESCRIPTION
## Summary
- handle printable keys in PTK using eager Keys.Any binding
- drop PTK named-key handlers and prevent_default calls

## Testing
- `pytest tests/test_macros_keypad.py::test_digit_resolves_to_keypad_alias -q`
- `pytest tests/test_macros_keys_fallback.py::test_char_binding_via_line_fallback -q`
- `pytest tests/test_exit_priority.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63973b35c832bb5c6e22bddd3fc86