### PR TITLE
feat: dynamic key bindings for REPL

### DIFF
--- a/mutants2/cli/repl.py
+++ b/mutants2/cli/repl.py
@@ -1,4 +1,18 @@
+try:  # prompt_toolkit is optional
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
+    from prompt_toolkit.filters import Condition
+except Exception:  # pragma: no cover - graceful fallback when ptk missing
+    PromptSession = KeyBindings = merge_key_bindings = Condition = None
+
+from mutants2.cli.keynames import KEYPAD
 from mutants2.engine.macros import resolve_bound_script
+
+
+def _fallback_char_for(key: str) -> str | None:
+    if key in KEYPAD:
+        return KEYPAD[key][1]
+    return key if len(key) == 1 else None
 
 
 class FallbackRepl:
@@ -17,49 +31,75 @@ class FallbackRepl:
 
 
 class PtkRepl:
-    def __init__(self, context) -> None:
-        self.ctx = context
-        from prompt_toolkit import PromptSession
-        from prompt_toolkit.key_binding import KeyBindings
+    def __init__(self, ctx):
+        self.ctx = ctx
+        self.session: PromptSession | None = None
+        self.core_bindings = KeyBindings()
+        self.dynamic_bindings = KeyBindings()
+        self.dynamic_chars: set[str] = set()
 
-        self.PromptSession = PromptSession
-        self.KeyBindings = KeyBindings
+    def _install_core_bindings(self) -> None:
+        kb = self.core_bindings
+
+        @kb.add("enter")
+        def _(event) -> None:
+            event.app.current_buffer.validate_and_handle()
+
+    def _rebuild_dynamic_bindings(self) -> None:
+        kb = KeyBindings()
+        store = self.ctx.macro_store
+        buffer_empty = Condition(lambda: event_app().current_buffer.text == "")
+        keys_enabled = Condition(lambda: getattr(store, "keys_enabled", True))
+
+        def event_app():
+            from prompt_toolkit.application.current import get_app
+            return get_app()
+
+        chars: set[str] = set()
+        for key, script in store.bindings().items():
+            ch = _fallback_char_for(key)
+            if not ch:
+                continue
+            if len(ch) == 1 and ch.isprintable():
+                chars.add(ch)
+
+        for ch in chars:
+            @kb.add(ch, filter=buffer_empty & keys_enabled)
+            def _(event, _ch=ch):
+                script = resolve_bound_script(store, _ch)
+                if script:
+                    event.app.current_buffer.reset()
+                    self.ctx.run_script(script)
+
+        self.dynamic_bindings = kb
+        self.dynamic_chars = chars
+
+    def _make_session(self) -> None:
+        bindings = merge_key_bindings([self.core_bindings, self.dynamic_bindings])
+        self.session = PromptSession(key_bindings=bindings, enable_history_search=True)
+
+    def _refresh_session_keymap(self) -> None:
+        assert self.session is not None
+        self.session.app.key_bindings = merge_key_bindings(
+            [self.core_bindings, self.dynamic_bindings]
+        )
 
     def run(self) -> None:
-        kb = self.KeyBindings()
-        session = self.PromptSession(key_bindings=kb, enable_history_search=True)
+        self._install_core_bindings()
+        self._rebuild_dynamic_bindings()
+        self._make_session()
 
-        from prompt_toolkit.keys import Keys
-
-        @kb.add(Keys.Any, eager=True)
-        def _(event):
-            """Printable keys: fire a macro only when the line is empty and a binding exists.
-            Otherwise, insert the typed character so normal typing works."""
-            store = self.ctx.macro_store
-            buf = event.app.current_buffer
-            ch = event.data  # printable char or '' for non-printables
-
-            if ch and store.keys_enabled and not buf.text:
-                script = resolve_bound_script(store, ch)
-                if getattr(store, "keys_debug", False):
-                    print(f"[#] key='{ch}' -> {'hit' if bool(script) else 'miss'}")
-
-                if script:
-                    # No prevent_default in PTK 3.x. Because this handler is eager,
-                    # default insertion won’t run; we just clear the line and execute.
-                    buf.reset()
-                    self.ctx.run_script(script)   # expand + dispatch each subcommand
-                    return
-
-            # Not handled: insert the character so normal typing works.
-            if ch:
-                buf.insert_text(ch)
+        self.ctx.macro_store._on_bindings_changed = self._on_bindings_changed
 
         while True:
             try:
-                line = session.prompt("> ")
+                line = self.session.prompt("> ")
             except (EOFError, KeyboardInterrupt):
                 print("")
                 break
             if self.ctx.dispatch_line(line):
                 break
+
+    def _on_bindings_changed(self) -> None:
+        self._rebuild_dynamic_bindings()
+        self._refresh_session_keymap()


### PR DESCRIPTION
## Summary
- rebuild PTK keymap from macro bindings instead of using a catch-all handler
- add MacroStore callback to notify the REPL when bindings change

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b63b841508832bb7ecd7ba1c96b506