### PR TITLE
Preempt printable key insertion for instant macros

### DIFF
--- a/mutants2/cli/repl.py
+++ b/mutants2/cli/repl.py
@@ -1,18 +1,31 @@
 try:  # prompt_toolkit is optional
     from prompt_toolkit import PromptSession
     from prompt_toolkit.key_binding import KeyBindings, merge_key_bindings
-    from prompt_toolkit.filters import Condition
 except Exception:  # pragma: no cover - graceful fallback when ptk missing
-    PromptSession = KeyBindings = merge_key_bindings = Condition = None
+    PromptSession = KeyBindings = merge_key_bindings = None
 
 from mutants2.cli.keynames import KEYPAD
 from mutants2.engine.macros import resolve_bound_script
 
 
 def _fallback_char_for(key: str) -> str | None:
+    """Return printable char for a key or keypad alias."""
     if key in KEYPAD:
         return KEYPAD[key][1]
-    return key if len(key) == 1 else None
+    return key if len(key) == 1 and key.isprintable() else None
+
+
+def _event_app():
+    from prompt_toolkit.application.current import get_app
+    return get_app()
+
+
+def _buffer_empty() -> bool:
+    return _event_app().current_buffer.text == ""
+
+
+def _keys_enabled(store) -> bool:
+    return getattr(store, "keys_enabled", True)
 
 
 class FallbackRepl:
@@ -36,7 +49,6 @@ class PtkRepl:
         self.session: PromptSession | None = None
         self.core_bindings = KeyBindings()
         self.dynamic_bindings = KeyBindings()
-        self.dynamic_chars: set[str] = set()
 
     def _install_core_bindings(self) -> None:
         kb = self.core_bindings
@@ -46,33 +58,30 @@ class PtkRepl:
             event.app.current_buffer.validate_and_handle()
 
     def _rebuild_dynamic_bindings(self) -> None:
-        kb = KeyBindings()
         store = self.ctx.macro_store
-        buffer_empty = Condition(lambda: event_app().current_buffer.text == "")
-        keys_enabled = Condition(lambda: getattr(store, "keys_enabled", True))
-
-        def event_app():
-            from prompt_toolkit.application.current import get_app
-            return get_app()
+        kb = KeyBindings()
 
         chars: set[str] = set()
-        for key, script in store.bindings().items():
+        for key in store.bindings().keys():
             ch = _fallback_char_for(key)
-            if not ch:
-                continue
-            if len(ch) == 1 and ch.isprintable():
+            if ch:
                 chars.add(ch)
 
         for ch in chars:
-            @kb.add(ch, filter=buffer_empty & keys_enabled)
+            @kb.add(ch, eager=True)
             def _(event, _ch=ch):
+                if not _keys_enabled(store) or not _buffer_empty():
+                    return
                 script = resolve_bound_script(store, _ch)
+                if getattr(store, "keys_debug", False):
+                    print(f"[#] key='{_ch}' -> {'hit' if bool(script) else 'miss'}")
                 if script:
                     event.app.current_buffer.reset()
                     self.ctx.run_script(script)
+                else:
+                    event.app.current_buffer.insert_text(_ch)
 
         self.dynamic_bindings = kb
-        self.dynamic_chars = chars
 
     def _make_session(self) -> None:
         bindings = merge_key_bindings([self.core_bindings, self.dynamic_bindings])

--- a/tests/test_ptk_repl.py
+++ b/tests/test_ptk_repl.py
@@ -1,0 +1,74 @@
+from types import SimpleNamespace
+
+from mutants2.cli.repl import PtkRepl
+from mutants2.engine.macros import MacroStore
+
+
+class DummyBuffer:
+    def __init__(self, text: str = "") -> None:
+        self.text = text
+
+    def reset(self) -> None:
+        self.text = ""
+
+    def insert_text(self, text: str) -> None:
+        self.text += text
+
+
+def _make_repl(run_log):
+    store = MacroStore()
+    ctx = SimpleNamespace(macro_store=store, run_script=lambda s: run_log.append(s))
+    repl = PtkRepl(ctx)
+    return repl, store
+
+
+def _binding_for(repl: PtkRepl, key: str):
+    [binding] = [b for b in repl.dynamic_bindings.bindings if b.keys == (key,)]
+    return binding
+
+
+def test_bound_char_runs_macro(monkeypatch):
+    run_log = []
+    repl, store = _make_repl(run_log)
+    store.bind("z", "look")
+    repl._rebuild_dynamic_bindings()
+    binding = _binding_for(repl, "z")
+
+    buf = DummyBuffer()
+    app = SimpleNamespace(current_buffer=buf)
+    monkeypatch.setattr("mutants2.cli.repl._event_app", lambda: app)
+    event = SimpleNamespace(app=app)
+
+    binding.handler(event)
+
+    assert run_log == ["look"]
+    assert buf.text == ""
+    assert binding.eager()
+
+
+def test_bound_char_ignored_when_buffer_not_empty(monkeypatch):
+    run_log = []
+    repl, store = _make_repl(run_log)
+    store.bind("z", "look")
+    repl._rebuild_dynamic_bindings()
+    binding = _binding_for(repl, "z")
+
+    buf = DummyBuffer("x")
+    app = SimpleNamespace(current_buffer=buf)
+    monkeypatch.setattr("mutants2.cli.repl._event_app", lambda: app)
+    event = SimpleNamespace(app=app)
+
+    binding.handler(event)
+
+    assert run_log == []
+    assert buf.text == "x"
+
+
+def test_unbound_char_not_registered():
+    run_log = []
+    repl, store = _make_repl(run_log)
+    store.bind("z", "look")
+    repl._rebuild_dynamic_bindings()
+
+    assert repl.dynamic_bindings.get_bindings_for_keys(("x",)) == []
+


### PR DESCRIPTION
## Summary
- Rebuild PTK dynamic bindings with `eager=True` so bound printable keys run macros immediately on an empty prompt
- Introduce helper utilities for buffer and key-store state to gate macro execution
- Add tests verifying eager macro bindings and ignoring of bound keys when text exists

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b63dda5f20832b9dc40abac8f62259