### PR TITLE
Improve item handling and command abbreviations

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -34,7 +34,6 @@ EXPLICIT_ALIASES = {
     "s": "south",
     "e": "east",
     "w": "west",
-    "i": "inventory",
     "inv": "inventory",
 }
 
@@ -187,30 +186,59 @@ def make_context(*, dev: bool = False):
             else:
                 print("(empty)")
         elif cmd == "get":
-            name = " ".join(args)
-            item = items.find_by_name(name)
-            ground_key = w.ground_item(p.year, p.x, p.y)
-            if item and ground_key == item.key:
-                w.set_ground_item(p.year, p.x, p.y, None)
-                p.inventory[item.key] = p.inventory.get(item.key, 0) + 1
-                print(f"You pick up {item.name}.")
-                render_room_view(p, w)
-            else:
-                print("You don't see that here.")
+            if not args:
+                ground_key = w.ground_item(p.year, p.x, p.y)
+                if ground_key:
+                    name = items.REGISTRY[ground_key].name
+                    print(f"On the ground: {name}")
+                else:
+                    print("On the ground: (nothing)")
+                ground_key = None
+            if args:
+                ground_key = w.ground_item(p.year, p.x, p.y)
+                ground_names = []
+                if ground_key:
+                    ground_names.append(items.REGISTRY[ground_key].name)
+                name, amb = items.resolve_item_prefix(" ".join(args), ground_names)
+                if amb:
+                    print("Ambiguous: " + ", ".join(amb))
+                elif not name:
+                    print(f'No item here matching "{' '.join(args)}".')
+                else:
+                    item = items.find_by_name(name)
+                    if item and ground_key == item.key:
+                        w.set_ground_item(p.year, p.x, p.y, None)
+                        p.inventory[item.key] = p.inventory.get(item.key, 0) + 1
+                        print(f"You pick up {item.name}.")
+                    else:
+                        print("You don't see that here.")
         elif cmd == "drop":
-            name = " ".join(args)
-            item = items.find_by_name(name)
-            if not item or p.inventory.get(item.key, 0) == 0:
-                print("You don't have that.")
-            elif w.ground_item(p.year, p.x, p.y):
-                print("You can only drop when the ground is empty here.")
+            if not args:
+                if p.inventory:
+                    print("Inventory: " + ", ".join(
+                        f"{items.REGISTRY[k].name} x{c}" for k, c in p.inventory.items()
+                    ))
+                else:
+                    print("(inventory empty)")
             else:
-                p.inventory[item.key] -= 1
-                if p.inventory[item.key] == 0:
-                    del p.inventory[item.key]
-                w.set_ground_item(p.year, p.x, p.y, item.key)
-                print(f"You drop {item.name}.")
-                render_room_view(p, w)
+                inv_names = [items.REGISTRY[k].name for k in p.inventory]
+                name, amb = items.resolve_item_prefix(" ".join(args), inv_names)
+                if amb:
+                    print("Ambiguous: " + ", ".join(amb))
+                elif not name:
+                    print(f'No item in inventory matching "{' '.join(args)}".')
+                else:
+                    item = items.find_by_name(name)
+                    if not item or p.inventory.get(item.key, 0) == 0:
+                        print("You don't have that.")
+                    elif w.ground_item(p.year, p.x, p.y):
+                        print("You can only drop when the ground is empty here.")
+                    else:
+                        p.inventory[item.key] -= 1
+                        if p.inventory[item.key] == 0:
+                            del p.inventory[item.key]
+                        w.set_ground_item(p.year, p.x, p.y, item.key)
+                        print(f"You drop {item.name}.")
         elif cmd == "help":
             topic = " ".join(args).strip().lower() if args else ""
             if topic in {"macros", "macro"}:

--- a/mutants2/engine/items.py
+++ b/mutants2/engine/items.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+import re
 from typing import Optional
 
 
@@ -42,3 +43,29 @@ def find_by_name(name: str) -> Optional[ItemDef]:
         if item.name.lower() == target:
             return item
     return None
+
+
+def norm_name(s: str) -> str:
+    """Normalize an item name for case-insensitive prefix matching."""
+    return re.sub(r"[^a-z0-9]", "", s.lower())
+
+
+def resolve_item_prefix(query: str, candidates: list[str]) -> tuple[Optional[str], list[str]]:
+    """Resolve ``query`` against ``candidates`` by prefix.
+
+    Returns a tuple of ``(match, ambiguous)`` where ``match`` is the matched
+    candidate name or ``None``.  ``ambiguous`` is a (possibly empty) list of
+    candidate names that matched when the query was ambiguous.  At most the
+    first 6 ambiguous matches are returned.
+    """
+
+    q = norm_name(query)
+    if not q:
+        return None, []
+    matches = [name for name in candidates if norm_name(name).startswith(q)]
+    if len(matches) == 1:
+        return matches[0], []
+    if not matches:
+        return None, []
+    return None, matches[:6]
+

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -52,8 +52,14 @@ Examples
 
 ABBREVIATIONS_NOTE = """Abbreviations
 -------------
-• Most commands accept the first 3 letters, e.g. `tra 2000`, `loo`, `cla`, `las`, `exi`, `inv`.
+• Non-direction commands accept the first 3 letters: `tra 2000`, `loo`, `cla`, `las`, `exi`, `inv`, `dro`, `mac`, `hel`.
 • Directions: use 1-letter (`n/s/e/w`) or the full word (`north/south/east/west`).
-  Partials like `nor` or `sou` are not accepted.
+  Partials like `nor` or `sou` are rejected.
+
+Items
+-----
+• Shorten item names by unique prefix among local candidates:
+     get nuc  → Nuclear-thong (if that’s the only matching item here)
+• `get`/`drop` print a short confirmation and do not refresh the room view.
 """
 

--- a/tests/test_commands_abbrev.py
+++ b/tests/test_commands_abbrev.py
@@ -34,7 +34,7 @@ def test_inventory_aliases(cli_runner):
     out = cli_runner.run_commands(["inv"])
     assert "(empty)" in out or "Inventory" in out
     out = cli_runner.run_commands(["i"])
-    assert "(empty)" in out or "Inventory" in out
+    assert "Unknown command" in out
 
 
 def test_get_drop_abbrevs(cli_runner, seeded_world_with_item):

--- a/tests/test_items_basic.py
+++ b/tests/test_items_basic.py
@@ -33,14 +33,15 @@ def test_pickup_and_drop_roundtrip(tmp_path):
     p = Player()
     w = World({(2000, 0, 0): 'ion_decay'}, {2000})
     persistence.save(p, w)
-    result = _run_game(['get Ion-Decay', 'inventory', 'drop Ion-Decay', 'inventory', 'exit'], tmp_path)
+    result = _run_game(['get Ion-Decay', 'look', 'inventory', 'drop Ion-Decay', 'look', 'inventory', 'exit'], tmp_path)
     out = result.stdout
     assert 'You pick up Ion-Decay.' in out
     assert 'On the ground lies: (nothing)' in out
     assert 'Ion-Decay x1' in out
     assert 'You drop Ion-Decay.' in out
-    assert 'On the ground lies: Ion-Decay' in out
-    assert '(empty)' in out.split('You drop Ion-Decay.')[-1]
+    after = out.split('You drop Ion-Decay.')[-1]
+    assert 'On the ground lies: Ion-Decay' in after
+    assert '(empty)' in after
 
 
 def test_inventory_rendering(tmp_path):

--- a/tests/test_items_prefix_and_abbrev.py
+++ b/tests/test_items_prefix_and_abbrev.py
@@ -1,0 +1,69 @@
+import os
+import pytest
+
+from mutants2.engine import persistence
+from mutants2.engine.world import World
+from mutants2.engine.player import Player
+
+
+@pytest.fixture
+def tile_with_item(tmp_path):
+    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
+    os.environ['HOME'] = str(tmp_path)
+    p = Player()
+    w = World({(2000, 0, 0): 'nuclear_thong'}, {2000})
+    persistence.save(p, w)
+    return None
+
+
+@pytest.fixture
+def inventory_with_item(tmp_path):
+    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
+    os.environ['HOME'] = str(tmp_path)
+    p = Player()
+    p.inventory['nuclear_thong'] = 1
+    w = World(seeded_years={2000})
+    persistence.save(p, w)
+    return None
+
+
+@pytest.fixture
+def inventory_with_ion_items(tmp_path):
+    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
+    os.environ['HOME'] = str(tmp_path)
+    p = Player()
+    p.inventory.update({'ion_decay': 1, 'ion_pack': 1})
+    w = World(seeded_years={2000})
+    persistence.save(p, w)
+    return None
+
+
+def test_get_does_not_render(cli_runner, tile_with_item):
+    out = cli_runner.run_commands(["look", "get nuc"])
+    assert out.count("***") == 2
+    assert "You pick up Nuclear-thong." in out
+
+
+def test_drop_does_not_render(cli_runner, inventory_with_item):
+    out = cli_runner.run_commands(["dro nuc"])
+    assert out.count("***") == 1
+    assert "You drop Nuclear-thong." in out
+
+
+def test_item_prefix_ambiguous(cli_runner, inventory_with_ion_items):
+    out = cli_runner.run_commands(["dro ion", "dro ion-dec"])
+    assert "Ambiguous:" in out
+    assert "You drop Ion-Decay" in out or "You drop Ion-Pack" in out
+
+
+def test_abbrev_rules(cli_runner):
+    assert "Unknown command" in cli_runner.run_commands(["i"])
+    assert "***" in cli_runner.run_commands(["loo"])
+    assert "Goodbye." in cli_runner.run_commands(["exi"])
+    assert "Unknown command" in cli_runner.run_commands(["nor"])
+    assert "***" in cli_runner.run_commands(["n"])
+
+
+def test_travel_still_renders(cli_runner):
+    out = cli_runner.run_commands(["tra 2100"])
+    assert "***" in out and "0E" in out


### PR DESCRIPTION
## Summary
- allow case-insensitive item prefix matching
- require 3-letter abbreviations for commands and remove `i` inventory shortcut
- update get/drop to print concise messages without auto-look
- document new rules and add tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b6f79d7c18832bbdcc1ac4c897a7f7