### PR TITLE
feat: expand look command and shadow sensing

### DIFF
--- a/mutants2/engine/gen.py
+++ b/mutants2/engine/gen.py
@@ -80,7 +80,7 @@ def seed_monsters_for_year(world: World, year: int, global_seed: int) -> None:
     import random
 
     rng = random.Random(hash((global_seed, year, "monsters_v1")))
-    target = min(30, max(0, round(0.02 * len(walkables))))
+    target = min(90, max(0, round(0.06 * len(walkables))))
     rng.shuffle(walkables)
     placed = 0
     for (x, y) in walkables:

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -128,6 +128,23 @@ class World:
     def monster_count(self, year: int) -> int:
         return sum(1 for (yr, _, _), _ in self._monsters.items() if yr == year)
 
+    _DIRS: dict[Direction, tuple[int, int]] = {
+        "north": (0, 1),
+        "south": (0, -1),
+        "east": (1, 0),
+        "west": (-1, 0),
+    }
+
+    def is_open(self, year: int, x: int, y: int, direction: Direction) -> bool:
+        """Return ``True`` if an open passage exists from ``(x, y)`` to ``direction``."""
+        grid = self.year(year).grid
+        return direction in grid.neighbors(x, y)
+
+    def step(self, x: int, y: int, direction: Direction) -> tuple[int, int]:
+        """Return coordinates stepped one tile in ``direction`` from ``(x, y)``."""
+        dx, dy = self._DIRS[direction]
+        return x + dx, y + dy
+
     def nearest_monster(
         self, year: int, x: int, y: int, max_dist: int = 4
     ) -> tuple[int, int, int] | None:

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -49,6 +49,20 @@ Examples
   do 7e3n; look
 """
 
+COMMANDS_HELP = """Commands: look, north, south, east, west, last, travel, class, inventory, get, drop, exit, macro, @name, do
+
+Look
+----
+• `look` — describe the current room.
+• `look <dir>` — peek into an adjacent room without moving. Example: `look n`, `loo west`.
+• If there is no open passage that way: “You can’t look that way.”
+
+Senses
+------
+• You may see: “A shadow flickers to the <dir>.” — there is a monster in that *adjacent open room*.
+• No distant sounds yet; footsteps will arrive when monsters move.
+"""
+
 
 ABBREVIATIONS_NOTE = """Abbreviations
 -------------

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -54,7 +54,7 @@ def test_persistence_of_class(tmp_path):
 def test_debug_unavailable_in_menu(tmp_path):
     home = tmp_path
     env = {'MUTANTS2_DEV': '1'}
-    result = run_cli('debug footsteps 2\n1\ndebug footsteps 2\nexit\n', home, env)
+    result = run_cli('debug shadow north\n1\ndebug shadow north\nexit\n', home, env)
     out = result.stdout
     assert 'Debug commands are available only in dev mode (in-game).' in out
     assert 'OK.' in out  # debug works in-game

--- a/tests/test_look_and_cues.py
+++ b/tests/test_look_and_cues.py
@@ -1,0 +1,61 @@
+import contextlib
+from io import StringIO
+
+from mutants2.engine import world as world_mod
+from mutants2.engine.player import Player
+from mutants2.engine.render import render_room_view
+
+
+def capture_render(w, p):
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        render_room_view(p, w)
+    return buf.getvalue()
+
+
+def test_look_dir_shows_adjacent(cli_runner):
+    out = cli_runner.run_commands(["loo e"])
+    assert "***" in out
+
+
+def test_look_dir_blocked(cli_runner):
+    out = cli_runner.run_commands(["look sou"])
+    assert "can't look that way" in out.lower()
+
+
+def test_shadow_only_adjacent_open():
+    w = world_mod.World()
+    w.year(2000)
+    w.place_monster(2000, 1, 0, "mutant")
+    p = Player()
+    out = capture_render(w, p)
+    assert "shadow flickers to the east" in out.lower()
+
+
+def test_no_shadow_two_away():
+    w = world_mod.World()
+    w.year(2000)
+    w.place_monster(2000, 2, 0, "mutant")
+    p = Player()
+    out = capture_render(w, p)
+    assert "shadow flickers" not in out.lower()
+
+
+def test_no_shadow_through_wall():
+    w = world_mod.World()
+    yr = w.year(2000)
+    yr.grid.adj[(0, 0)].discard("east")
+    yr.grid.adj[(1, 0)].discard("west")
+    w.place_monster(2000, 1, 0, "mutant")
+    p = Player()
+    out = capture_render(w, p)
+    assert "shadow flickers" not in out.lower()
+
+
+def test_density_tripled():
+    w = world_mod.World(global_seed=123)
+    w.year(2000)
+    walkables = len(list(w.walkable_coords(2000)))
+    count = w.monster_count(2000)
+    assert count <= min(90, round(0.06 * walkables))
+    assert count >= 1

--- a/tests/test_monsters_basic.py
+++ b/tests/test_monsters_basic.py
@@ -43,20 +43,10 @@ def test_nearest_monster_cues():
     w = World()
     w.year(2000)
     _clear_monsters(w)
-    w.place_monster(2000, 2, 0, "mutant")
+    w.place_monster(2000, 1, 0, "mutant")
     p = Player()
     out = render_output(w, p)
     assert "shadow flickers to the east" in out.lower()
-
-
-def test_footsteps_radius():
-    w = World()
-    w.year(2000)
-    _clear_monsters(w)
-    w.place_monster(2000, 4, 0, "mutant")
-    p = Player()
-    out = render_output(w, p)
-    assert "footsteps nearby" in out.lower()
 
 
 def test_no_cues_when_none_near():
@@ -66,7 +56,6 @@ def test_no_cues_when_none_near():
     p = Player()
     out = render_output(w, p)
     assert "shadow flickers" not in out.lower()
-    assert "footsteps nearby" not in out.lower()
 
 
 @pytest.fixture
@@ -84,8 +73,7 @@ def cli_runner_dev(tmp_path):
 
 
 def test_dev_spawn_here(cli_runner_dev):
-    out = cli_runner_dev.run_commands(["debug mon here", "look"])
-    assert "shadow" in out.lower() or "footsteps" in out.lower()
-    out2 = cli_runner_dev.run_commands(["debug mon here", "look"])
-    tail = out2.lower().split("on the ground lies:")[-1]
-    assert "shadow" not in tail and "footsteps" not in tail
+    out = cli_runner_dev.run_commands(["debug mon here"])
+    assert "spawned monster" in out.lower()
+    out2 = cli_runner_dev.run_commands(["debug mon here"])
+    assert "removed monster" in out2.lower()

--- a/tests/test_senses_dev.py
+++ b/tests/test_senses_dev.py
@@ -29,30 +29,21 @@ def test_debug_commands_rejected_without_dev(cli_runner):
     assert "Debug commands are available only in dev mode." in out
 
 
-def test_shadow_and_footsteps_render_once(cli_runner):
+def test_shadow_render_once(cli_runner):
     enable_dev_env()
     out = cli_runner.run_commands([
         "debug clear",
         "debug shadow north",
         "debug shadow east",
-        "debug footsteps 3",
         "look",
         "look",
     ])
     assert "A shadow flickers to the north." in out
     assert "A shadow flickers to the east." in out
-    assert "You hear footsteps nearby." in out
     parts = out.split("On the ground lies:")
     assert len(parts) >= 3
     seg = parts[-1]
     assert "A shadow flickers" not in seg
-    assert "footsteps" not in seg
-
-
-def test_invalid_footsteps_distance(cli_runner):
-    enable_dev_env()
-    out = cli_runner.run_commands(["debug footsteps 0"])
-    assert "must be 1..4" in out or "Invalid" in out
 
 
 def test_debug_clear(cli_runner):
@@ -62,4 +53,4 @@ def test_debug_clear(cli_runner):
         "debug clear",
         "look",
     ])
-    assert "A shadow flickers" not in out
+    assert "A shadow flickers to the south" not in out


### PR DESCRIPTION
## Summary
- allow `look <dir>` for cardinal directions and block closed passages
- limit shadow cues to adjacent open rooms and drop footsteps sounds
- triple monster spawn density for more encounters
- document commands and cues in help and tests

## Testing
- `pytest >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68b7063034e8832b8b8eaf0b2cba83db