### PR TITLE
Add minimal combat system with attack, rest, and status

### DIFF
--- a/mutants2/engine/monsters.py
+++ b/mutants2/engine/monsters.py
@@ -5,10 +5,11 @@ from dataclasses import dataclass
 class MonsterDef:
     key: str
     name: str
+    base_hp: int = 3  # small, so combat resolves quickly
 
 
 REGISTRY = {
-    "mutant": MonsterDef("mutant", "Mutant"),
+    "mutant": MonsterDef("mutant", "Mutant", base_hp=3),
 }
 
 SPAWN_KEYS = tuple(REGISTRY.keys())

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -6,6 +6,7 @@ from typing import Dict, Tuple, Set
 
 from .player import Player
 from .world import World
+from . import monsters as monsters_mod
 
 from . import gen
 
@@ -23,7 +24,7 @@ class Save:
 SAVE_PATH = Path(os.path.expanduser("~/.mutants2/save.json"))
 
 
-def load() -> Tuple[Player, Dict[Tuple[int, int, int], str], Dict[Tuple[int, int, int], str], Set[int], Save]:
+def load() -> Tuple[Player, Dict[Tuple[int, int, int], str], Dict[Tuple[int, int, int], dict], Set[int], Save]:
     try:
         with open(SAVE_PATH) as fh:
             data = json.load(fh)
@@ -35,29 +36,40 @@ def load() -> Tuple[Player, Dict[Tuple[int, int, int], str], Dict[Tuple[int, int
         clazz = data.get("class")
         player = Player(year=year, clazz=clazz)
         player.positions.update(positions)
+        player.max_hp = int(data.get("max_hp", player.max_hp))
+        player.hp = int(data.get("hp", player.max_hp))
         player.inventory.update({k: int(v) for k, v in data.get("inventory", {}).items()})
         ground = {
             tuple(int(n) for n in key.split(',')): val
             for key, val in data.get("ground", {}).items()
         }
-        monsters = {
-            tuple(int(n) for n in key.split(',')): val
-            for key, val in data.get("monsters", {}).items()
-        }
+        monsters_data: Dict[Tuple[int, int, int], dict] = {}
+        for key, val in data.get("monsters", {}).items():
+            coord = tuple(int(n) for n in key.split(','))
+            if isinstance(val, dict):
+                m_key = val.get("key")
+                hp = val.get("hp")
+            else:
+                m_key = val
+                hp = None
+            if m_key is None:
+                continue
+            base = monsters_mod.REGISTRY[m_key].base_hp
+            monsters_data[coord] = {"key": m_key, "hp": int(hp) if hp is not None else base}
         seeded = {int(y) for y in data.get("seeded_years", [])}
         save_meta = Save(
             global_seed=int(data.get("global_seed", gen.SEED)),
             last_topup_date=data.get("last_topup_date"),
         )
-        return player, ground, monsters, seeded, save_meta
+        return player, ground, monsters_data, seeded, save_meta
     except FileNotFoundError:
         player = Player()
         ground: Dict[Tuple[int, int, int], str] = {}
-        monsters: Dict[Tuple[int, int, int], str] = {}
+        monsters_data: Dict[Tuple[int, int, int], dict] = {}
         seeded: Set[int] = set()
         save_meta = Save()
-        save(player, World(ground, seeded, monsters, global_seed=save_meta.global_seed), save_meta)
-        return player, ground, monsters, seeded, save_meta
+        save(player, World(ground, seeded, monsters_data, global_seed=save_meta.global_seed), save_meta)
+        return player, ground, monsters_data, seeded, save_meta
 
 
 def save(player: Player, world: World, save_meta: Save) -> None:
@@ -70,14 +82,16 @@ def save(player: Player, world: World, save_meta: Save) -> None:
                 for y, (x, yy) in player.positions.items()
             },
             "class": player.clazz,
+            "hp": player.hp,
+            "max_hp": player.max_hp,
             "inventory": {k: v for k, v in player.inventory.items()},
             "ground": {
                 f"{y},{x},{yy}": item_key
                 for (y, x, yy), item_key in world.ground.items()
             },
             "monsters": {
-                f"{y},{x},{yy}": key
-                for (y, x, yy), key in world.monsters.items()
+                f"{y},{x},{yy}": {"key": data["key"], "hp": data["hp"]}
+                for (y, x, yy), data in world.monsters.items()
             },
             "seeded_years": list(world.seeded_years),
             "global_seed": save_meta.global_seed,

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -24,6 +24,8 @@ class Player:
     clazz: str | None = None
     senses: SensesBuffer = field(default_factory=SensesBuffer, repr=False)
     inventory: Dict[str, int] = field(default_factory=dict)
+    hp: int = 10
+    max_hp: int = 10
 
     @property
     def x(self) -> int:
@@ -54,4 +56,15 @@ class Player:
             self.year = target_year
         world.year(self.year)  # ensure world generation
         self.positions[self.year] = (0, 0)
+
+    # Combat helpers ---------------------------------------------------------
+
+    def heal_full(self) -> None:
+        self.hp = self.max_hp
+
+    def take_damage(self, dmg: int) -> None:
+        self.hp = max(0, self.hp - max(0, dmg))
+
+    def is_dead(self) -> bool:
+        return self.hp <= 0
 

--- a/mutants2/engine/render.py
+++ b/mutants2/engine/render.py
@@ -1,7 +1,7 @@
 from .world import World
 from .player import Player
 from .senses import SensesCues
-from . import items
+from . import items, monsters
 
 
 def _adjacent_dirs() -> tuple[str, ...]:
@@ -31,6 +31,10 @@ def render_room_view(player: Player, world: World, *, consume_cues: bool = True)
     for d in ("north", "south", "east", "west"):
         if d in cues.shadow_dirs:
             lines.append(f"A shadow flickers to the {d}.")
+    m = world.monster_here(player.year, player.x, player.y)
+    if m:
+        name = monsters.REGISTRY[m["key"]].name
+        lines.append(f"A {name} is here.")
     for line in lines:
         print(line)
     grid = world.year(player.year).grid

--- a/tests/test_combat_minimal.py
+++ b/tests/test_combat_minimal.py
@@ -1,0 +1,70 @@
+import os
+import pytest
+
+from mutants2.engine import persistence
+from mutants2.engine.world import World
+from mutants2.engine.player import Player
+from pathlib import Path
+
+
+@pytest.fixture
+def world_with_mutant_on_start(tmp_path):
+    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
+    os.environ['HOME'] = str(tmp_path)
+    p = Player()
+    w = World(monsters={(2000, 0, 0): {'key': 'mutant', 'hp': 3}}, seeded_years={2000})
+    save = persistence.Save()
+    persistence.save(p, w, save)
+    return None
+
+
+@pytest.fixture
+def empty_start_world(tmp_path):
+    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
+    os.environ['HOME'] = str(tmp_path)
+    p = Player()
+    w = World(seeded_years={2000})
+    save = persistence.Save()
+    persistence.save(p, w, save)
+    return None
+
+
+def test_attack_kills_with_few_hits(world_with_mutant_on_start, cli_runner):
+    out = cli_runner.run_commands(["att", "att"])
+    assert "You defeat the Mutant" in out
+
+
+def test_retaliation_and_death_respawn(world_with_mutant_on_start, cli_runner):
+    out = cli_runner.run_commands(["att"])
+    assert "The Mutant hits you" in out
+    # reset world with low player HP for death test
+    save_path = Path(os.environ["HOME"]) / '.mutants2' / 'save.json'
+    persistence.SAVE_PATH = save_path
+    p = Player()
+    p.max_hp = p.hp = 1
+    w = World(monsters={(2000, 0, 0): {'key': 'mutant', 'hp': 3}}, seeded_years={2000})
+    save = persistence.Save()
+    persistence.save(p, w, save)
+    out2 = cli_runner.run_commands(["att", "att", "att", "att"])
+    assert "You have died." in out2
+    assert "0E : 0N" in out2
+
+
+def test_cannot_rest_in_danger(world_with_mutant_on_start, cli_runner):
+    out = cli_runner.run_commands(["res"])
+    assert "can’t rest" in out.lower()
+
+
+def test_rest_heals_when_safe(empty_start_world, cli_runner):
+    out = cli_runner.run_commands(["res"])
+    assert "recover" in out
+
+
+def test_status_shows_hp_and_coords(empty_start_world, cli_runner):
+    out = cli_runner.run_commands(["sta"])
+    assert "HP:" in out and "Year:" in out
+
+
+def test_room_line_shows_monster_present(world_with_mutant_on_start, cli_runner):
+    out = cli_runner.run_commands(["loo"])
+    assert "A Mutant is here." in out


### PR DESCRIPTION
## Summary
- introduce HP tracking for players and monsters
- add attack, rest, and status commands with room monster cues
- persist HP stats and monster health
- test minimal combat loop

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b70a0a0e0c832bb50c6fcaaea66b1f