### PR TITLE
PR#7b — Make senses match captures + look <dir|item|monster> (pre-combat correctness)

### DIFF
--- a/mutants2/engine/items.py
+++ b/mutants2/engine/items.py
@@ -43,6 +43,8 @@ __all__ = [
     "find_by_name",
     "norm_name",
     "resolve_item_prefix",
+    "resolve_prefix",
+    "describe",
 ]
 
 
@@ -77,4 +79,18 @@ def resolve_item_prefix(query: str, candidates: list[str]) -> tuple[Optional[str
     if not matches:
         return None, []
     return None, matches[:6]
+
+
+def resolve_prefix(query: str, ground_names: list[str], inv_names: list[str]) -> Optional[str]:
+    name, amb = resolve_item_prefix(query, ground_names + inv_names)
+    if name and not amb:
+        return name
+    return None
+
+
+def describe(name: str) -> str:
+    item = find_by_name(name)
+    if item:
+        return f"You see {item.name}."
+    return f"You see {name}."
 

--- a/mutants2/engine/monsters.py
+++ b/mutants2/engine/monsters.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 
 
+from .items import norm_name
+
 @dataclass(frozen=True)
 class MonsterDef:
     key: str
@@ -13,3 +15,18 @@ REGISTRY = {
 }
 
 SPAWN_KEYS = tuple(REGISTRY.keys())
+
+
+def resolve_prefix(query: str, names: list[str]) -> str | None:
+    q = norm_name(query)
+    if not q:
+        return None
+    matches = [n for n in names if norm_name(n).startswith(q)]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def describe(key: str) -> str:
+    name = REGISTRY[key].name
+    return f"It's a {name}."

--- a/mutants2/engine/render.py
+++ b/mutants2/engine/render.py
@@ -4,26 +4,26 @@ from .senses import SensesCues
 from . import items, monsters
 
 
-def _adjacent_dirs() -> tuple[str, ...]:
-    return ("east", "west", "north", "south")
-
-
-def senses_lines_for_tile(world: World, year: int, x: int, y: int) -> list[str]:
-    lines: list[str] = []
-    for d in _adjacent_dirs():
+def shadow_line(world: World, year: int, x: int, y: int) -> list[str]:
+    for d in ("east", "west", "north", "south"):
         if world.is_open(year, x, y, d):
             ax, ay = world.step(x, y, d)
             if world.has_monster(year, ax, ay):
-                lines.append(f"A shadow flickers to the {d}.")
-                break
-    return lines
+                return [f"A shadow flickers to the {d}."]
+    return []
 
 
-def render_room_view(player: Player, world: World, *, consume_cues: bool = True) -> None:
+def footsteps_line(ctx) -> list[str]:
+    return ["You hear footsteps nearby."] if getattr(ctx, "_footsteps_this_tick", False) else []
+
+
+def render_room_view(player: Player, world: World, context=None, *, consume_cues: bool = True) -> None:
     print("---")
     print(f"Class: {player.clazz}")
     print(f"{player.x}E : {player.y}N")
-    lines = senses_lines_for_tile(world, player.year, player.x, player.y)
+    lines: list[str] = []
+    lines.extend(shadow_line(world, player.year, player.x, player.y))
+    lines.extend(footsteps_line(context))
     if consume_cues:
         cues = player.senses.pop()
     else:
@@ -48,6 +48,8 @@ def render_room_view(player: Player, world: World, *, consume_cues: bool = True)
         print(f"On the ground lies: {name}")
     else:
         print("On the ground lies: (nothing)")
+    if context is not None:
+        context._footsteps_this_tick = False
 
 
 # Backwards compatibility

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -55,12 +55,14 @@ Look
 ----
 • `look` — describe the current room.
 • `look <dir>` — peek into an adjacent room without moving. Example: `look n`, `loo west`.
-• If there is no open passage that way: “You can’t look that way.”
+• `look <item>` — inspect a ground or inventory item by unique prefix.
+• `look <monster>` — inspect a visible monster (here or in an adjacent open room).
+• If blocked or no such target: “You can’t look that way.”
 
 Senses
 ------
-• You may see: “A shadow flickers to the <dir>.” — there is a monster in that *adjacent open room*.
-• No distant sounds yet; footsteps will arrive when monsters move.
+• “A shadow flickers to the <dir>.” — a monster is in that adjacent open room.
+• “You hear footsteps nearby.” — a monster moved within about four tiles this turn.
 """
 
 

--- a/tests/test_senses_and_look_targets.py
+++ b/tests/test_senses_and_look_targets.py
@@ -1,0 +1,71 @@
+import contextlib
+from io import StringIO
+
+import pytest
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+
+
+@pytest.fixture
+def world():
+    w = world_mod.World()
+    w.year(2000)
+    return w
+
+
+@pytest.fixture
+def cli(world, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    p = Player()
+    p.clazz = "Warrior"
+    save = persistence.Save()
+    ctx = make_context(p, world, save)
+
+    class CLI:
+        def run(self, commands):
+            buf = StringIO()
+            with contextlib.redirect_stdout(buf):
+                for cmd in commands:
+                    ctx.dispatch_line(cmd)
+            return buf.getvalue()
+
+    return CLI()
+
+
+def test_shadow_adjacent_only(cli, world):
+    world.place_monster(2000, 1, 0, "mutant")
+    out = cli.run(["look"])
+    assert "shadow flickers to the east" in out.lower()
+    yr = world.year(2000)
+    yr.grid.adj[(0, 0)].discard("east")
+    yr.grid.adj[(1, 0)].discard("west")
+    out = cli.run(["look"])
+    assert "shadow flickers" not in out.lower()
+
+
+def test_look_dir_and_blocked(cli):
+    out = cli.run(["loo n"])
+    assert "***" in out
+    out = cli.run(["look sou"])
+    assert "can't look that way" in out.lower()
+
+
+def test_look_item_and_monster(cli, world):
+    world.place_item(2000, 0, 0, "gold_chunk")
+    out = cli.run(["look gold"])
+    assert "gold-chunk" in out.lower()
+    world.place_monster(2000, 1, 0, "mutant")
+    out = cli.run(["look mut"])
+    assert "mutant" in out.lower()
+
+
+def test_footsteps_only_on_move(cli, world):
+    out1 = cli.run(["look"])
+    assert "footsteps" not in out1.lower()
+    out2 = cli.run(["n"])
+    assert "footsteps" not in out2.lower()
+    world.force_monster_move_within4()
+    out3 = cli.run(["n"])
+    assert "footsteps nearby" in out3.lower()


### PR DESCRIPTION
## Summary
- Allow `look` to target directions, items, and nearby monsters
- Emit footsteps cues when monsters move within range
- Document updated `look` usage and sensory messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b70feff104832bbe6c71b36d99d314