### PR TITLE
Hotfix: footsteps trigger only on movement and monsters wait for aggro

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -121,13 +121,12 @@ def make_context(p, w, save, *, dev: bool = False):
         world=w,
         save=save,
         _arrivals_this_tick=[],
-        _footstep_dir=None,
-        _yell_dir=None,
+        _footsteps_event=None,
         _entry_yells=[],
         _pre_shadow_lines=[],
         _needs_render=False,
         _last_turn_consumed=False,
-        )
+    )
 
     def handle_macro(rest: str) -> None:
         if rest.startswith("add "):
@@ -463,23 +462,21 @@ def make_context(p, w, save, *, dev: bool = False):
             context._pre_shadow_lines = render_mod.shadow_lines(w, p)
         consumed = context._last_turn_consumed
         if consumed:
-            arrivals, foot, yell = w.move_monsters_one_tick(p.year, p)
+            arrivals, foot = w.move_monsters_one_tick(p.year, p)
             context._arrivals_this_tick = arrivals
-            context._footstep_dir = foot
-            context._yell_dir = yell
+            context._footsteps_event = foot
             w.turn += 1
         if context._needs_render:
             render_room_view(p, w, context)
             context._needs_render = False
         else:
-            for msg in context._entry_yells:
+            for msg in render_mod.entry_yell_lines(context):
                 print(msg)
-            context._entry_yells = []
             for msg in render_mod.arrival_lines(context):
                 print(msg)
                 name = msg.split(" has just arrived")[0]
                 print(f"{name} is here.")
-            for msg in render_mod.audio_lines(context):
+            for msg in render_mod.footsteps_lines(context):
                 print(msg)
         return False
 

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -56,6 +56,7 @@ def load() -> Tuple[Player, Dict[Tuple[int, int, int], list[str]], Dict[Tuple[in
                 m_key = val.get("key")
                 hp = val.get("hp")
                 name = val.get("name")
+                # ``aggro`` state is persisted to keep passive monsters from moving
                 aggro = val.get("aggro", False)
                 mid = val.get("id")
             else:

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -64,10 +64,16 @@ Look
 Senses
 ------
 • Monsters start passive. Entering their room triggers a 50/50 roll for each to aggro — success shows “<Name> yells at you!” and they’ll chase on later turns.
-• LOOK takes a turn. Monsters may move after each of your turns.
-• You may see multiple shadow directions (“west, north”). Footsteps and yelling only occur when something moved.
+• LOOK takes a turn. Aggro’d monsters may move after each of your turns.
+• You may see multiple shadow directions (“west, north”).
 • “Faint … far to the <dir>” means farther away; “Loud … to the <dir>” means closer.
 • When a monster enters your room you’ll see: “<Name> has just arrived from the <dir>.” and “<Name> is here.”
+
+Audio
+-----
+• You only hear footsteps when a monster actually moved that turn.
+• Monsters do not move until they aggro.
+• A monster yells exactly once, when it aggroes as you enter its room.
 """
 
 

--- a/tests/test_audio_movement_only.py
+++ b/tests/test_audio_movement_only.py
@@ -1,0 +1,103 @@
+import contextlib
+from io import StringIO
+
+import pytest
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+
+
+@pytest.fixture
+def seeded_rng(monkeypatch):
+    import hashlib, random
+    from mutants2.engine import rng, monsters as monsters_mod
+
+    def fake_hrand(*parts):
+        h = hashlib.md5(str(parts).encode()).hexdigest()
+        seed = int(h, 16) & 0xFFFFFFFF
+        return random.Random(seed)
+
+    monkeypatch.setattr(rng, "hrand", fake_hrand)
+    monsters_mod._next_id = 1
+
+
+@pytest.fixture
+def world_passive_monster_south(seeded_rng):
+    w = world_mod.World()
+    w.year(2000)
+    w.place_monster(2000, 0, 2, "mutant")
+    return w
+
+
+@pytest.fixture
+def world_passive_monster_here_after_move(seeded_rng):
+    w = world_mod.World()
+    w.year(2000)
+    w.place_monster(2000, 0, 1, "mutant")
+    # Extra aggro monster that can move toward the player on subsequent turns
+    w.place_monster(2000, 2, 1, "mutant")
+    w.monster_here(2000, 2, 1)["aggro"] = True
+    return w
+
+
+@pytest.fixture
+def world_aggro_monster_two_south(seeded_rng):
+    w = world_mod.World()
+    w.year(2000)
+    w.place_monster(2000, 0, 3, "mutant")
+    w.monster_here(2000, 0, 3)["aggro"] = True
+    return w
+
+
+@pytest.fixture
+def cli(tmp_path, monkeypatch, request):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    save = persistence.Save()
+    p = Player()
+    p.clazz = "Warrior"
+    world = None
+    for name in (
+        "world_passive_monster_south",
+        "world_passive_monster_here_after_move",
+        "world_aggro_monster_two_south",
+    ):
+        if name in request.fixturenames:
+            world = request.getfixturevalue(name)
+            break
+    if world is None:
+        world = world_mod.World()
+        world.year(2000)
+    ctx = make_context(p, world, save)
+
+    class CLI:
+        def run(self, commands):
+            buf = StringIO()
+            with contextlib.redirect_stdout(buf):
+                for cmd in commands:
+                    ctx.dispatch_line(cmd)
+            return buf.getvalue()
+
+    return CLI()
+
+
+def test_no_footsteps_before_aggro(cli, world_passive_monster_south):
+    out1 = cli.run(["look"])
+    out2 = cli.run(["look"])
+    out3 = cli.run(["look"])
+    assert "footsteps" not in (out1 + out2 + out3).lower()
+
+
+def test_yell_once_on_entry_then_move(cli, world_passive_monster_here_after_move):
+    out = cli.run(["n"])
+    if "yells at you" in out.lower():
+        out2 = cli.run(["look"])
+        assert "footsteps" in out2.lower() or "has just arrived" in out2.lower()
+        out3 = cli.run(["look"])
+        assert "yells at you" not in out3.lower()
+
+
+def test_footsteps_only_when_moved(cli, world_aggro_monster_two_south):
+    out = cli.run(["look"])
+    text = out.lower()
+    assert "loud" in text and "footsteps" in text and "south" in text


### PR DESCRIPTION
## Summary
- gate monster movement unless aggroed
- report footsteps only when a monster actually moves and drop recurring yells
- update help text and add audio movement tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b75c4b91fc832bb52086bcbb082325