### PR TITLE
UI: shadows before arrivals with red styling

### DIFF
--- a/mutants2/__main__.py
+++ b/mutants2/__main__.py
@@ -46,7 +46,7 @@ def main() -> None:
 
     while True:
         try:
-            line = input("> ")
+            line = input("")
         except (EOFError, KeyboardInterrupt):
             print()
             break

--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -480,6 +480,8 @@ def make_context(p, w, save, *, dev: bool = False):
         return handle_command(cmd, args)
 
     def dispatch_line(line: str) -> bool:
+        if line.strip():
+            print(line.strip())
         before = (p.year, p.x, p.y)
         dispatch_macro(line)
         if not context.running:
@@ -507,10 +509,7 @@ def make_context(p, w, save, *, dev: bool = False):
             context._needs_render = False
         for msg in render_mod.entry_yell_lines(context):
             print(msg)
-        for msg in render_mod.arrival_lines(context):
-            print(msg)
-            name = msg.split(" has just arrived")[0]
-            print(f"{name} is here.")
+        # arrivals are rendered inside ``render_room_view``
         for msg in render_mod.footsteps_lines(context):
             print(msg)
         return False

--- a/mutants2/engine/render.py
+++ b/mutants2/engine/render.py
@@ -45,6 +45,7 @@ def render_room_view(player: Player, world: World, context=None, *, consume_cues
         player.y,
         include_shadows=True,
         shadow_dirs_extra=cues.shadow_dirs,
+        context=context,
     )
     print(text)
 

--- a/mutants2/render.py
+++ b/mutants2/render.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .ui.theme import red, green, cyan, yellow, white, SEP
 from .engine.items import stack_for_render
 
+
 def _room_desc(world, year, x, y):
     if hasattr(world, "room_description"):
         try:
@@ -12,7 +13,24 @@ def _room_desc(world, year, x, y):
     return "You are here."
 
 
-def render_room_at(world, year, x, y, *, include_shadows: bool = True, shadow_dirs_extra=()):
+def render_room_at(
+    world,
+    year,
+    x,
+    y,
+    *,
+    include_shadows: bool = True,
+    shadow_dirs_extra=(),
+    context=None,
+):
+    """Render the room at ``(year, x, y)``.
+
+    When ``context`` is provided, it may carry pre-computed shadow and arrival
+    information produced during the current tick.  This function is responsible
+    for ordering those events and suppressing presence lines when arrivals
+    occurred.
+    """
+
     out: list[str] = []
 
     # (a) room description
@@ -28,38 +46,71 @@ def render_room_at(world, year, x, y, *, include_shadows: bool = True, shadow_di
         if world.is_open(year, x, y, d):
             out.append(cyan(f"{d} – area continues."))
 
-    # (d) separator
-    out.append(SEP)
-
-    # (e) ground items
+    # (d/e) ground items followed by a single separator
     ground_names = [it.name for it in world.items_on_ground(year, x, y)]
     if ground_names:
         out.append(yellow("On the ground lies:"))
         line = ", ".join(stack_for_render(ground_names))
         out.append(cyan(line))
-        out.append(SEP)
+    # Always end the header section with one separator
+    out.append(SEP)
 
-    # (g) monsters here
-    here = list(world.monsters_here(year, x, y))
-    if here:
-        for m in here:
-            name = m.get("name") or m.get("key")
-            out.append(white(f"{name} is here."))
-        out.append(SEP)
-
-    # (i) shadows
+    shadow_lines: list[str] = []
     if include_shadows:
-        dirs = set(shadow_dirs_extra)
-        for d in ("east", "west", "north", "south"):
-            if world.is_open(year, x, y, d):
-                ax, ay = world.step(x, y, d)
-                if world.has_monster(year, ax, ay):
-                    dirs.add(d)
-        if dirs:
-            out.append(yellow(f"You see shadows to the {', '.join(sorted(dirs))}."))
+        if context is not None:
+            pre = getattr(context, "_pre_shadow_lines", []) or []
+            if pre:
+                shadow_lines = [yellow(s) for s in pre]
+            context._pre_shadow_lines = []
+        if not shadow_lines:
+            dirs = set(shadow_dirs_extra)
+            for d in ("east", "west", "north", "south"):
+                if world.is_open(year, x, y, d):
+                    ax, ay = world.step(x, y, d)
+                    if world.has_monster(year, ax, ay):
+                        dirs.add(d)
+            if dirs:
+                shadow_lines = [
+                    yellow(f"You see shadows to the {', '.join(sorted(dirs))}.")
+                ]
+
+    arrivals = []
+    if context is not None:
+        arrivals = getattr(context, "_arrivals_this_tick", []) or []
+
+    if shadow_lines:
+        out.extend(shadow_lines)
+    if shadow_lines and arrivals:
+        out.append(SEP)
+    if arrivals:
+        for msg in arrivals:
+            out.append(red(msg))
+        if context is not None:
+            context._suppress_presence_this_tick = True
+    else:
+        if context is not None:
+            context._suppress_presence_this_tick = False
+
+    if context is not None:
+        context._arrivals_this_tick = []
+
+    # Presence lines only when no arrivals were printed
+    if not arrivals:
+        here = list(world.monsters_here(year, x, y))
+        if here:
+            for m in here:
+                name = m.get("name") or m.get("key")
+                out.append(white(f"{name} is here."))
 
     return "\n".join(out)
 
 
-def render_current_room(player, world, *, include_shadows: bool = True):
-    return render_room_at(world, player.year, player.x, player.y, include_shadows=include_shadows)
+def render_current_room(player, world, *, include_shadows: bool = True, context=None):
+    return render_room_at(
+        world,
+        player.year,
+        player.x,
+        player.y,
+        include_shadows=include_shadows,
+        context=context,
+    )

--- a/tests/test_senses_capture_like.py
+++ b/tests/test_senses_capture_like.py
@@ -96,7 +96,8 @@ def test_faint_then_loud_then_shadows_progression(cli, staged_world_far_south):
 def test_arrival_message(cli, staged_world_adjacent_south):
     out = cli.run(["loo"])
     assert "has just arrived from the west" in out
-    assert "is here" in out
+    # Presence should be suppressed on the same tick as the arrival
+    assert "is here" not in out.split("has just arrived")[-1]
 
 
 def test_multi_shadow(cli, world_two_adjacent):

--- a/tests/test_senses_still_correct.py
+++ b/tests/test_senses_still_correct.py
@@ -69,5 +69,6 @@ def test_arrival_after_chase(tmp_path, monkeypatch, staged_world_aggro_east):
         ctx.dispatch_line("loo")
     out2 = buf2.getvalue()
     assert "has just arrived from the west" in out2.lower()
-    assert "is here" in out2.lower()
+    # Presence lines are suppressed on the same tick as an arrival
+    assert "is here" not in out2.lower().split("has just arrived")[-1]
 

--- a/tests/test_ui_arrival_order.py
+++ b/tests/test_ui_arrival_order.py
@@ -1,0 +1,89 @@
+import contextlib
+from io import StringIO
+
+import pytest
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+
+
+@pytest.fixture
+def world():
+    w = world_mod.World()
+    w.year(2000)
+    return w
+
+
+@pytest.fixture
+def player():
+    p = Player()
+    p.clazz = "Warrior"
+    return p
+
+
+@pytest.fixture
+def cli(world, player, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    save = persistence.Save()
+    ctx = make_context(player, world, save)
+
+    class CLI:
+        def run(self, commands):
+            buf = StringIO()
+            with contextlib.redirect_stdout(buf):
+                for cmd in commands:
+                    ctx.dispatch_line(cmd)
+            return buf.getvalue()
+
+    return CLI()
+
+
+@pytest.fixture
+def staged_adjacent_then_arrival(world):
+    # Adjacent east monster for immediate arrival when staying put
+    world.place_monster(2000, 1, 0, "mutant")
+    world.monster_here(2000, 1, 0)["aggro"] = True
+    # Monster two tiles north that will arrive after the player moves north
+    world.place_monster(2000, 0, -2, "mutant")
+    world.monster_here(2000, 0, -2)["aggro"] = True
+    return world
+
+
+@pytest.fixture
+def staged_arrival_now(world):
+    world.place_monster(2000, 1, 0, "mutant")
+    world.monster_here(2000, 1, 0)["aggro"] = True
+    return world
+
+
+def test_shadows_then_arrival(cli, staged_adjacent_then_arrival):
+    out = cli.run(["n"])
+    s_idx = out.find("You see shadows")
+    a_idx = out.find("has just arrived")
+    assert s_idx != -1 and a_idx != -1 and s_idx < a_idx
+
+
+def test_no_presence_on_arrival_tick(cli, staged_arrival_now):
+    out = cli.run(["look"])
+    assert "has just arrived" in out
+    assert "is here." not in out.split("has just arrived")[-1]
+
+
+def test_arrival_colored_red(cli, staged_arrival_now):
+    out = cli.run(["look"])
+    assert "\x1b[31m" in out and "\x1b[0m" in out
+
+
+def test_prompt_echo_without_arrow(cli):
+    out = cli.run(["w"])
+    assert "\n> w" not in out
+    assert out.startswith("w\n")
+
+
+def test_single_separator_between_events(cli, staged_adjacent_then_arrival):
+    out = cli.run(["look"])
+    chunk = out.split("You see shadows")[1]
+    assert chunk.count("***") >= 1
+    # guard against duplicate separators around the arrival block
+    assert "***\n***" not in chunk

--- a/tests/test_ui_parity.py
+++ b/tests/test_ui_parity.py
@@ -38,7 +38,7 @@ def test_render_order_and_copy():
     assert exit_lines and exit_lines[0].endswith("area continues.")
     # separators and sections order
     idxs = [i for i, ln in enumerate(lines) if ln == "***"]
-    assert idxs and lines[idxs[0] + 1] == "On the ground lies:"
-    assert "Mutant is here." in lines[idxs[1] + 1]
-    assert lines[-1].startswith("You see shadows to the")
+    assert idxs and lines[idxs[0] - 2] == "On the ground lies:"
+    assert "You see shadows to the" in lines[idxs[0] + 1]
+    assert "Mutant is here." in lines[-1]
     assert "Class:" not in out


### PR DESCRIPTION
## Summary
- Render pre-move shadows before arrivals and suppress same-tick presence lines
- Echo raw command input and remove ">" prompt
- Add tests covering arrival ordering and prompt behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b85363b898832bb567653cf14b973f