### PR TITLE
Support stacked monsters and denser world generation

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -241,11 +241,14 @@ def make_context(p, w, save, *, dev: bool = False):
                 print("You can't look that way.")
                 return False
             ax, ay = w.step(p.x, p.y, d)
-            tmp = Player()
-            tmp.clazz = p.clazz
-            tmp.year = p.year
-            tmp.positions = {p.year: (ax, ay)}
-            render_room_view(tmp, w, context, consume_cues=False)
+            text = render_mod.render_room_at(
+                w,
+                p.year,
+                ax,
+                ay,
+                include_shadows=False,
+            )
+            print(text)
             return False
 
         print("You can't look that way.")

--- a/mutants2/engine/gen.py
+++ b/mutants2/engine/gen.py
@@ -22,14 +22,15 @@ def seed_items(world: World, year: int, grid: Grid) -> None:
         return
     walkable = list(world.walkable_coords(year))
     rand = random.Random(SEED + year)
-    target = round(0.05 * len(walkable))
+    rate = 0.05 * 5.0
+    target = min(round(0.5 * len(walkable)), round(rate * len(walkable)))
     if target <= 0:
         world.seeded_years.add(year)
         return
-    cells = rand.sample(walkable, min(target, len(walkable)))
+    cells = rand.choices(walkable, k=target)
     for x, y in cells:
         key = rand.choice(SPAWNABLE_KEYS)
-        world.set_ground_item(year, x, y, key)
+        world.add_ground_item(year, x, y, key)
     world.seeded_years.add(year)
 
 
@@ -40,11 +41,12 @@ def seed_monsters_for_year(world: World, year: int, global_seed: int) -> None:
     import random
 
     rng = random.Random(hash((global_seed, year, "monsters_v1")))
-    target = min(90, max(0, round(0.06 * len(walkables))))
+    rate = 0.06 * 3.0
+    target = min(round(0.35 * len(walkables)), max(0, round(rate * len(walkables))))
     rng.shuffle(walkables)
     placed = 0
     for (x, y) in walkables:
-        if world.item_at(year, x, y) is None and not world.has_monster(year, x, y):
+        if world.item_at(year, x, y) is None:
             world.place_monster(year, x, y, SPAWN_KEYS[0])
             placed += 1
             if placed >= target:

--- a/mutants2/render.py
+++ b/mutants2/render.py
@@ -96,11 +96,15 @@ def render_room_at(
 
     # Presence lines only when no arrivals were printed
     if not arrivals:
-        here = list(world.monsters_here(year, x, y))
-        if here:
-            for m in here:
-                name = m.get("name") or m.get("key")
-                out.append(white(f"{name} is here."))
+        names = [m.get("name") or m.get("key") for m in world.monsters_here(year, x, y)]
+        if names:
+            if len(names) == 1:
+                line = f"{names[0]} is here."
+            elif len(names) == 2:
+                line = f"{names[0]}, and {names[1]} are here with you."
+            else:
+                line = f"{', '.join(names[:-1])}, and {names[-1]} are here with you."
+            out.append(white(line))
 
     return "\n".join(out)
 

--- a/tests/test_aggro_on_entry.py
+++ b/tests/test_aggro_on_entry.py
@@ -4,7 +4,7 @@ import contextlib
 import pytest
 
 from mutants2.cli.shell import make_context
-from mutants2.engine import persistence, world as world_mod
+from mutants2.engine import persistence, world as world_mod, monsters as monsters_mod
 from mutants2.engine.player import Player
 
 
@@ -12,6 +12,9 @@ from mutants2.engine.player import Player
 def world_with_passive_mutant_here(seeded_rng):
     w = world_mod.World()
     w.year(2000)
+    for x, y, _ in list(w.monster_positions(2000)):
+        w.remove_monster(2000, x, y)
+    monsters_mod._next_id = 1
     w.place_monster(2000, 0, 0, "mutant")  # passive by default
     return w
 

--- a/tests/test_items_basic.py
+++ b/tests/test_items_basic.py
@@ -20,11 +20,10 @@ def test_initial_spawn_approx_five_percent(tmp_path, monkeypatch):
     p, ground, monsters, seeded, save = persistence.load()
     w = World(ground, seeded, monsters, global_seed=save.global_seed)
     w.year(p.year)
-    count = sum(1 for (yr, _, _), _ in w.ground.items() if yr == p.year)
-    assert 25 <= count <= 60
-    # Ensure one item per tile
+    count = sum(len(v) for (yr, _, _), v in w.ground.items() if yr == p.year)
+    assert 180 <= count <= 270
     coords = {(x, y) for (yr, x, y) in w.ground if yr == p.year}
-    assert len(coords) == count
+    assert len(coords) <= count
 
 
 def test_pickup_and_drop_roundtrip(tmp_path):

--- a/tests/test_items_topup_daily.py
+++ b/tests/test_items_topup_daily.py
@@ -27,13 +27,8 @@ def test_topup_advances_next_day():
     w, p, save = make_game()
     save.fake_today_override = "2025-09-01"
     daily_topup_if_needed(w, p, save)
-    # remove some items
-    removed = 0
-    for key in list(w.ground.keys()):
-        yr, _, _ = key
-        if yr == p.year and removed < 5:
-            del w.ground[key]
-            removed += 1
+    # remove all items in current year to drop below target
+    w.ground = {k: v for k, v in w.ground.items() if k[0] != p.year}
     save.fake_today_override = "2025-09-02"
     n = daily_topup_if_needed(w, p, save)
     assert n > 0

--- a/tests/test_look_and_cues.py
+++ b/tests/test_look_and_cues.py
@@ -50,5 +50,5 @@ def test_density_tripled():
     w.year(2000)
     walkables = len(list(w.walkable_coords(2000)))
     count = w.monster_count(2000)
-    assert count <= min(90, round(0.06 * walkables))
+    assert count <= min(round(0.35 * walkables), round(0.18 * walkables))
     assert count >= 1

--- a/tests/test_passive_vs_aggro_movement.py
+++ b/tests/test_passive_vs_aggro_movement.py
@@ -4,7 +4,7 @@ import contextlib
 import pytest
 
 from mutants2.cli.shell import make_context
-from mutants2.engine import persistence, world as world_mod
+from mutants2.engine import persistence, world as world_mod, monsters as monsters_mod
 from mutants2.engine.player import Player
 
 
@@ -12,6 +12,9 @@ from mutants2.engine.player import Player
 def world_with_passive_here(seeded_rng):
     w = world_mod.World()
     w.year(2000)
+    for x, y, _ in list(w.monster_positions(2000)):
+        w.remove_monster(2000, x, y)
+    monsters_mod._next_id = 1
     w.place_monster(2000, 0, 0, "mutant")  # passive by default
     return w
 

--- a/tests/test_peek_echo_multi_spawn.py
+++ b/tests/test_peek_echo_multi_spawn.py
@@ -1,0 +1,120 @@
+import contextlib
+from io import StringIO
+
+import pytest
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+
+
+previous_baseline_monsters = 54
+previous_baseline_items = 45
+
+
+@pytest.fixture
+def world():
+    w = world_mod.World()
+    w.year(2000)
+    for x, y, _ in list(w.monster_positions(2000)):
+        w.remove_monster(2000, x, y)
+    w.ground.clear()
+    return w
+
+
+@pytest.fixture
+def player():
+    p = Player()
+    p.clazz = "Warrior"
+    return p
+
+
+def _make_cli(world, player, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    save = persistence.Save()
+    ctx = make_context(player, world, save)
+
+    class CLI:
+        def run(self, commands):
+            buf = StringIO()
+            with contextlib.redirect_stdout(buf):
+                for cmd in commands:
+                    ctx.dispatch_line(cmd)
+            return buf.getvalue()
+
+        @property
+        def world(self):
+            return world
+
+        @property
+        def player(self):
+            return player
+
+    return CLI()
+
+
+@pytest.fixture
+def cli(world, player, tmp_path, monkeypatch):
+    return _make_cli(world, player, tmp_path, monkeypatch)
+
+
+@pytest.fixture
+def world_with_adjacent_monster(world):
+    world.place_monster(2000, 0, 2, "mutant")
+    return world
+
+
+@pytest.fixture
+def world_with_two_monsters_here(world):
+    world.place_monster(2000, 0, 0, "mutant")
+    world.place_monster(2000, 0, 0, "mutant")
+    return world
+
+
+@pytest.fixture
+def staged_arrival_now_into_room_with_another_monster(world):
+    world.place_monster(2000, 0, 0, "mutant")
+    world.place_monster(2000, 1, 0, "mutant")
+    world.monster_here(2000, 1, 0)["aggro"] = True
+    return world
+
+
+@pytest.fixture
+def seeded_world():
+    w = world_mod.World()
+    w.year(2000)
+    return w
+
+
+@pytest.fixture
+def cli_seeded(seeded_world, player, tmp_path, monkeypatch):
+    return _make_cli(seeded_world, player, tmp_path, monkeypatch)
+
+
+def test_peek_has_no_shadows(cli, world_with_adjacent_monster):
+    out = cli.run(["look so"])
+    assert "You see shadows" not in out
+
+
+def test_single_echo(cli):
+    out = cli.run(["inv"])
+    assert out.splitlines().count("inv") == 1
+    assert "> inv" not in out
+
+
+def test_multi_monster_presence_line(cli, world_with_two_monsters_here):
+    out = cli.run(["look"])
+    assert "are here with you." in out and "," in out and "and" in out
+
+
+def test_arrival_suppresses_presence(cli, staged_arrival_now_into_room_with_another_monster):
+    out = cli.run(["look"])
+    assert "has just arrived" in out
+    assert "is here with you" not in out and "is here." not in out.split("has just arrived")[-1]
+
+
+def test_spawn_scaling(cli_seeded):
+    m_count = cli_seeded.world.count_monsters_for_year(cli_seeded.player.year)
+    i_count = cli_seeded.world.count_items_for_year(cli_seeded.player.year)
+    assert m_count >= previous_baseline_monsters * 3 * 0.8
+    assert i_count >= previous_baseline_items * 5 * 0.8


### PR DESCRIPTION
## Summary
- allow stacking multiple monsters per tile and render combined presence lines
- remove peek shadows and keep single command echo
- increase monster and item seeding rates (3× monsters, 5× items)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b85c3625c0832bada7c4610f09f19d