### PR TITLE
feat: add smoke test harness and dev tooling

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+{
+  "name": "mutants2",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.11"
+    }
+  },
+  "postCreateCommand": "pip install -U pip && pip install -e '.[dev]'",
+  "customizations": {
+    "vscode": {
+      "extensions": ["ms-python.python", "charliermarsh.ruff"]
+    }
+  }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - run: pip install -e '.[dev]'
+      - run: pytest -q tests/smoke
+
+  full:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - run: pip install -e '.[dev]'
+      - run: pytest -q
+      - run: pyright mutants2 --level warning

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 __pycache__/
 *.pyc
+captures/
+logs/
+screenshots/
+artifacts/
+dist/
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.5
+    hooks:
+      - id: ruff
+        args: ["--fix"]
+  - repo: https://github.com/psf/black
+    rev: 24.3.0
+    hooks:
+      - id: black
+        language_version: python3.11

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: smoke test fmt lint
+
+smoke:
+	pytest -q tests/smoke
+
+test:
+	pytest -q
+
+fmt:
+	ruff check --fix .
+	black .
+
+lint:
+	ruff check .
+	black --check .

--- a/docs/CODEX_GUIDE.md
+++ b/docs/CODEX_GUIDE.md
@@ -1,0 +1,39 @@
+# Mutants2 Codex Guide
+
+## Project map
+- `mutants2/` – game source. Entry points:
+  - `__main__.py` – CLI startup.
+  - `cli/shell.py` – command dispatch loop.
+  - `engine/` – world, player, items, monsters, persistence.
+- `tests/` – canonical test suite.
+- `tests/smoke/` – fast deterministic smoke tests.
+- `docs/` – documentation.
+
+## Areas to avoid touching
+- Anything under `tests/` except within `tests/smoke/` when adding new smoke tests.
+- `mutants2/engine/*` contains core game logic; modify with care.
+
+## Determinism
+The game world and monster placement are driven by a single RNG seed. Both the
+runtime and `testing_api.run_one` pass a `seed` which feeds into the world's
+`global_seed`. Use the same seed to reproduce scenarios. The smoke tests rely on
+this determinism; no footsteps or yells should appear unless aggro actually
+occurs.
+
+## Test strategy
+- `make smoke` / `pytest -q tests/smoke` – runs in a few seconds and is used for
+  pull requests and quick local checks.
+- `make test` / `pytest` – full suite with slower, more exhaustive coverage.
+- CI runs the smoke set on PRs and the full suite plus type checks on `main`.
+
+## Style
+- Code is formatted with **Black** and linted by **Ruff**.
+- Use `make fmt` before committing and `make lint` in CI or locally.
+- Prefer small commits with descriptive messages (present tense, imperative).
+
+## Commit message style
+```
+feat: short summary in present tense
+
+Longer description if necessary.
+```

--- a/mutants2/testing_api.py
+++ b/mutants2/testing_api.py
@@ -1,0 +1,40 @@
+"""Helpers for deterministic, single-command CLI tests."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+import tempfile
+from pathlib import Path
+
+from .cli.shell import make_context
+from .engine import world as world_mod, persistence
+from .engine.player import Player
+
+
+def run_one(cmd: str, *, seed: int = 42, year: int | None = None) -> str:
+    """Execute ``cmd`` and return the game's printed output.
+
+    The world is bootstrapped deterministically using ``seed``.  Only one
+    command is executed and its output captured.  ``year`` selects the starting
+    year (default 2000).
+    """
+
+    start_year = 2000 if year is None else year
+    save = persistence.Save(global_seed=seed)
+    w = world_mod.World(global_seed=seed)
+    w.year(start_year)
+    p = Player(year=start_year, clazz="Warrior")
+    ctx = make_context(p, w, save)
+
+    buf = io.StringIO()
+    with tempfile.TemporaryDirectory() as tmp:
+        persistence.SAVE_PATH = Path(tmp) / "save.json"
+        with contextlib.redirect_stdout(buf):
+            ctx.dispatch_line(cmd)
+    output = buf.getvalue()
+    buf.close()
+    # Strip ANSI color codes just in case
+    output = re.sub(r"\x1b\[[0-9;]*m", "", output)
+    return output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,22 @@ dependencies = []
 
 [tool.pytest.ini_options]
 addopts = "-q"
+
+[project.optional-dependencies]
+dev = [
+  "pytest",
+  "pre-commit",
+  "black",
+  "ruff",
+  "mypy",
+  "pyright",
+]
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]
+
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+

--- a/tests/smoke/test_cli_smoke.py
+++ b/tests/smoke/test_cli_smoke.py
@@ -1,0 +1,19 @@
+from mutants2.testing_api import run_one
+
+
+def test_look_smoke():
+    out = run_one("look")
+    lines = out.strip().splitlines()
+    assert lines[0] == "look"
+    assert lines.count("look") == 1
+    assert "Compass:" in out
+    assert "***" in out
+
+
+def test_travel_smoke():
+    out = run_one("travel 2100")
+    lines = out.strip().splitlines()
+    assert lines[0] == "travel 2100"
+    assert lines.count("travel 2100") == 1
+    assert "Compass:" in out
+    assert "footsteps" not in out.lower()


### PR DESCRIPTION
## Summary
- add deterministic `run_one` testing API and smoke tests
- document project map and style in CODEX_GUIDE
- provide devcontainer, Makefile, pre-commit, and CI for fast smoke checks

## Testing
- `ruff check --fix mutants2/testing_api.py tests/smoke/test_cli_smoke.py`
- `black mutants2/testing_api.py tests/smoke/test_cli_smoke.py`
- `pyright mutants2/testing_api.py tests/smoke/test_cli_smoke.py --level warning`
- `pytest -q tests/smoke`


------
https://chatgpt.com/codex/tasks/task_e_68b8657c2674832bb44184b96b1729f6