### PR TITLE
Fix compass orientation and arrival UI

### DIFF
--- a/mutants2/engine/render.py
+++ b/mutants2/engine/render.py
@@ -16,9 +16,9 @@ def entry_yell_lines(ctx) -> list[str]:
 
 
 def arrival_lines(ctx) -> list[str]:
-    msgs = getattr(ctx, "_arrivals_this_tick", []) or []
+    infos = getattr(ctx, "_arrivals_this_tick", []) or []
     ctx._arrivals_this_tick = []
-    return msgs
+    return [f"{name} has just arrived from the {d}." for _, name, d in infos]
 
 
 def footsteps_lines(ctx) -> list[str]:

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -23,8 +23,8 @@ def in_bounds(x: int, y: int) -> bool:
 DIR: Dict[str, Tuple[int, int]] = {
     "east": (1, 0),
     "west": (-1, 0),
-    "north": (0, -1),
-    "south": (0, 1),
+    "north": (0, 1),
+    "south": (0, -1),
 }
 
 ORDER = ("east", "west", "north", "south")
@@ -39,7 +39,7 @@ def _dir_from(px: int, py: int, tx: int, ty: int) -> str:
     dx, dy = tx - px, ty - py
     if abs(dx) >= abs(dy):
         return "east" if dx > 0 else "west"
-    return "south" if dy > 0 else "north"
+    return "north" if dy > 0 else "south"
 
 
 @dataclass
@@ -294,18 +294,21 @@ class World:
     def any_aggro_in_year(self, year: int) -> bool:
         return any(m.get("aggro", False) for _, _, m in self.monster_positions(year))
 
-    def move_monsters_one_tick(self, year: int, player) -> tuple[list[str], tuple[str, str] | None]:
+    def move_monsters_one_tick(
+        self, year: int, player
+    ) -> tuple[list[tuple[int, str, str]], tuple[str, str] | None]:
         """Advance ONLY aggro'd monsters one step each.
 
-        Returns arrival messages for monsters entering the player's tile and a
-        footsteps event of the form ``("faint"|"loud", dir)`` or ``None`` if no
-        monster movement produced audible footsteps.
+        Returns arrival info for monsters entering the player's tile as a list
+        of ``(id, name, direction)`` and a footsteps event of the form
+        ``("faint"|"loud", dir)`` or ``None`` if no monster movement produced
+        audible footsteps.
         """
 
         if not self.any_aggro_in_year(year):
             return [], None
 
-        arrivals: list[str] = []
+        arrivals: list[tuple[int, str, str]] = []
         footsteps_event: tuple[str, str] | None = None
 
         px, py = player.x, player.y
@@ -349,7 +352,7 @@ class World:
             self._monsters.setdefault((year, nx, ny), []).append(m)
 
             if (nx, ny) == (px, py):
-                arrivals.append(f"{m['name']} has just arrived from the {d}.")
+                arrivals.append((m["id"], m["name"], d))
 
             if footsteps_event is None:
                 dist = abs(px - nx) + abs(py - ny)

--- a/tests/smoke/test_compass_and_ui.py
+++ b/tests/smoke/test_compass_and_ui.py
@@ -1,0 +1,69 @@
+import contextlib
+import io
+import re
+import tempfile
+from pathlib import Path
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import world as world_mod, persistence
+from mutants2.engine.player import Player
+
+
+def run_commands(cmds):
+    save = persistence.Save(global_seed=42)
+    w = world_mod.World(global_seed=42)
+    w.year(2000)
+    p = Player(year=2000, clazz="Warrior")
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with tempfile.TemporaryDirectory() as tmp:
+        persistence.SAVE_PATH = Path(tmp) / "save.json"
+        with contextlib.redirect_stdout(buf):
+            for c in cmds:
+                ctx.dispatch_line(c)
+    out = buf.getvalue()
+    buf.close()
+    return re.sub(r"\x1b\[[0-9;]*m", "", out)
+
+
+def test_compass_south_then_look():
+    out = run_commands(["s", "look"])
+    assert "Compass: (0E : -1N)" in out
+
+
+def test_compass_north_then_look():
+    out = run_commands(["n", "look"])
+    assert "Compass: (0E : 1N)" in out
+
+
+def test_single_command_echo():
+    out = run_commands(["look"])
+    lines = out.strip().splitlines()
+    assert lines.count("look") == 1
+
+
+def test_resident_and_arrival_rendering():
+    save = persistence.Save(global_seed=42)
+    w = world_mod.World(global_seed=42)
+    w.year(2000)
+    p = Player(year=2000, clazz="Warrior")
+    w.place_monster(2000, 0, 0, "night_stalker")
+    w.place_monster(2000, 1, 0, "mutant")
+    w.monster_here(2000, 1, 0)["aggro"] = True
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with tempfile.TemporaryDirectory() as tmp:
+        persistence.SAVE_PATH = Path(tmp) / "save.json"
+        with contextlib.redirect_stdout(buf):
+            ctx.dispatch_line("look")
+    out = re.sub(r"\x1b\[[0-9;]*m", "", buf.getvalue())
+    buf.close()
+    assert out.splitlines().count("look") == 1
+    assert "Night-Stalker is here" in out
+    assert "Mutant is here" not in out
+    assert "You see shadows" in out
+    assert out.count("has just arrived from") == 1
+    presence_idx = out.find("Night-Stalker is here")
+    shadow_idx = out.find("You see shadows")
+    arrival_idx = out.find("has just arrived from")
+    assert presence_idx < shadow_idx < arrival_idx

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -39,7 +39,7 @@ def test_direction_aliases_one_letter(tmp_path):
     assert result.returncode == 0
     # One render per command plus initial
     assert result.stdout.count('***') >= 5
-    assert 'Compass: (0E : -1N)' in result.stdout
+    assert 'Compass: (0E : 1N)' in result.stdout
     assert 'Compass: (1E : 0N)' in result.stdout
 
 

--- a/tests/test_movement.py
+++ b/tests/test_movement.py
@@ -6,10 +6,10 @@ def test_player_movement(capsys):
     w = World()
     p = Player()
     assert p.move('north', w)
-    assert (p.x, p.y) == (0, -1)
+    assert (p.x, p.y) == (0, 1)
     assert p.move('west', w)
     capsys.readouterr()
-    assert (p.x, p.y) == (-1, -1)
+    assert (p.x, p.y) == (-1, 1)
 
 
 def test_diagonal_rejected(capsys):

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -13,7 +13,7 @@ def test_save_load(tmp_path, monkeypatch):
     save = persistence.Save()
     persistence.save(p, w, save)
     p2, ground, monsters, seeded, _ = persistence.load()
-    assert (p2.year, p2.x, p2.y) == (2100, 0, -1)
+    assert (p2.year, p2.x, p2.y) == (2100, 0, 1)
     w2 = World(ground, seeded, monsters)
     p2.travel(w2)
     assert (p2.x, p2.y) == (0, 0)

--- a/tests/test_senses_capture_like.py
+++ b/tests/test_senses_capture_like.py
@@ -65,7 +65,7 @@ def staged_world_adjacent_south(world):
 @pytest.fixture
 def world_two_adjacent(world):
     world.place_monster(2000, 1, 0, "mutant")
-    world.place_monster(2000, 0, 1, "mutant")
+    world.place_monster(2000, 0, -1, "mutant")
     return world
 
 

--- a/tests/test_travel.py
+++ b/tests/test_travel.py
@@ -12,7 +12,7 @@ def test_travel_and_positions():
     assert (p.year, p.x, p.y) == (2100, 0, 0)
 
     assert p.move("north", w)
-    assert (p.x, p.y) == (0, -1)
+    assert (p.x, p.y) == (0, 1)
 
     p.travel(w)
     assert (p.year, p.x, p.y) == (2000, 0, 0)

--- a/tests/test_ui_arrival_order.py
+++ b/tests/test_ui_arrival_order.py
@@ -45,8 +45,8 @@ def staged_adjacent_then_arrival(world):
     world.place_monster(2000, 1, 0, "mutant")
     world.monster_here(2000, 1, 0)["aggro"] = True
     # Monster two tiles north that will arrive after the player moves north
-    world.place_monster(2000, 0, -2, "mutant")
-    world.monster_here(2000, 0, -2)["aggro"] = True
+    world.place_monster(2000, 0, 2, "mutant")
+    world.monster_here(2000, 0, 2)["aggro"] = True
     return world
 
 

--- a/tests/test_ui_parity.py
+++ b/tests/test_ui_parity.py
@@ -39,6 +39,7 @@ def test_render_order_and_copy():
     # separators and sections order
     idxs = [i for i, ln in enumerate(lines) if ln == "***"]
     assert idxs and lines[idxs[0] - 2] == "On the ground lies:"
-    assert "You see shadows to the" in lines[idxs[0] + 1]
-    assert "Mutant is here." in lines[-1]
+    assert "Mutant is here." in lines[idxs[0] + 1]
+    assert len(idxs) > 1 and "You see shadows to the" in lines[idxs[1] + 1]
+    assert lines[-1].startswith("You see shadows to the")
     assert "Class:" not in out


### PR DESCRIPTION
## Summary
- Correct north/south axes so moving north increases y and compass displays signed coordinates
- Refactor room rendering to separate resident monsters from arrivals, showing presence before shadows and arrival messages
- Add smoke tests for compass sign, single command echo, and resident+arrival UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8711ad23c832bbf61b3efd4fda720