### PR TITLE
feat: improve command handling and aggro mechanics

### DIFF
--- a/mutants2/__main__.py
+++ b/mutants2/__main__.py
@@ -34,13 +34,19 @@ def main() -> None:
     w = world_mod.World(ground, seeded, monsters, global_seed=save.global_seed)
 
     if p.clazz is None:
+        w.reset_all_aggro()
         class_menu(p, w, save, in_game=False)
 
     placed = daily_topup_if_needed(w, p, save)
     if dev and placed:
         print(f"[dev] Daily top-up placed {placed} items.")
 
+    yells = w.on_entry_aggro_check(
+        p.year, p.x, p.y, p, seed_parts=(save.global_seed, w.turn)
+    )
     render_room_view(p, w)
+    for line in yells:
+        print(line)
 
     ctx = make_context(p, w, save, dev=dev)
 
@@ -56,4 +62,3 @@ def main() -> None:
 
 if __name__ == "__main__":  # pragma: no cover
     main()
-

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -51,7 +51,9 @@ class Cell:
 class Grid:
     """A simple 4-neighbour grid with fully open connectivity."""
 
-    def __init__(self, width: int = GRID_MAX - GRID_MIN, height: int = GRID_MAX - GRID_MIN):
+    def __init__(
+        self, width: int = GRID_MAX - GRID_MIN, height: int = GRID_MAX - GRID_MIN
+    ):
         self.width = width
         self.height = height
 
@@ -147,7 +149,9 @@ class World:
             return items[0]
         return None
 
-    def set_ground_item(self, year: int, x: int, y: int, item_key: Optional[str]) -> None:
+    def set_ground_item(
+        self, year: int, x: int, y: int, item_key: Optional[str]
+    ) -> None:
         key = (year, x, y)
         if item_key is None:
             self.ground.pop(key, None)
@@ -180,7 +184,11 @@ class World:
     # Helpers for daily top-up -------------------------------------------------
 
     def known_years(self) -> list[int]:
-        yrs = set(self.years.keys()) | {y for (y, _, _) in self.ground.keys()} | set(self.seeded_years)
+        yrs = (
+            set(self.years.keys())
+            | {y for (y, _, _) in self.ground.keys()}
+            | set(self.seeded_years)
+        )
         return sorted(yrs)
 
     def walkable_coords(self, year: int) -> Iterable[Tuple[int, int]]:
@@ -233,7 +241,9 @@ class World:
     def monsters_here(self, year: int, x: int, y: int) -> list[dict]:
         return list(self._monsters.get((year, x, y), []))
 
-    def on_entry_aggro_check(self, year: int, x: int, y: int, player, seed_parts=()) -> list[str]:
+    def on_entry_aggro_check(
+        self, year: int, x: int, y: int, player, seed_parts=()
+    ) -> list[str]:
         """Mark monsters as seen and run 50/50 aggro rolls on this tile."""
 
         from .rng import hrand
@@ -250,11 +260,14 @@ class World:
                 yells.append(f"{m['name']} yells at you!")
         return yells
 
+    def reset_all_aggro(self) -> None:
+        for lst in self._monsters.values():
+            for m in lst:
+                m["aggro"] = False
+
     def place_monster(self, year: int, x: int, y: int, key: str) -> bool:
         coord = (year, x, y)
-        self._monsters.setdefault(coord, []).append(
-            monsters_mod.spawn(key, year, x, y)
-        )
+        self._monsters.setdefault(coord, []).append(monsters_mod.spawn(key, year, x, y))
         return True
 
     def ensure_monster(self, year: int, x: int, y: int, key: str) -> None:
@@ -313,7 +326,7 @@ class World:
 
         px, py = player.x, player.y
 
-        for (x, y, m) in list(self.monster_positions(year)):
+        for x, y, m in list(self.monster_positions(year)):
             if not m.get("aggro", False):
                 continue  # passive monsters never move
 
@@ -330,7 +343,9 @@ class World:
                     if (
                         best is None
                         or cand[3] < best[3]
-                        or (cand[3] == best[3] and ORDER.index(d) < ORDER.index(best[0]))
+                        or (
+                            cand[3] == best[3] and ORDER.index(d) < ORDER.index(best[0])
+                        )
                     ):
                         best = cand
 
@@ -372,7 +387,9 @@ class World:
                     dirs.append(d)
         return dirs
 
-    def adjacent_monster_names(self, year: int, x: int, y: int) -> list[tuple[str, str]]:
+    def adjacent_monster_names(
+        self, year: int, x: int, y: int
+    ) -> list[tuple[str, str]]:
         results: list[tuple[str, str]] = []
         for d in ("east", "west", "north", "south"):
             if self.is_open(year, x, y, d):
@@ -384,7 +401,9 @@ class World:
                     results.append((name, key))
         return results
 
-    def resolve_monster_prefix_nearby(self, year: int, x: int, y: int, query: str) -> str | None:
+    def resolve_monster_prefix_nearby(
+        self, year: int, x: int, y: int, query: str
+    ) -> str | None:
         candidates: list[str] = []
         name_to_key: dict[str, str] = {}
         here = self.monster_here(year, x, y)
@@ -406,7 +425,10 @@ class World:
         for yr, x0, y0, x1, y1 in self._recent_monster_moves:
             if yr != year:
                 continue
-            if abs(x0 - x) + abs(y0 - y) <= radius or abs(x1 - x) + abs(y1 - y) <= radius:
+            if (
+                abs(x0 - x) + abs(y0 - y) <= radius
+                or abs(x1 - x) + abs(y1 - y) <= radius
+            ):
                 hit = True
                 break
         self._recent_monster_moves.clear()

--- a/mutants2/render.py
+++ b/mutants2/render.py
@@ -105,8 +105,11 @@ def render_room_at(
             out.append(SEP)
 
     if arrivals:
-        for aid, name, d in sorted(arrivals):
+        arr_sorted = sorted(arrivals)
+        for i, (aid, name, d) in enumerate(arr_sorted):
             out.append(red(f"{name} has just arrived from the {d}."))
+            if i < len(arr_sorted) - 1:
+                out.append(SEP)
 
     return "\n".join(out)
 

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -49,7 +49,7 @@ Examples
   do 7e3n; look
 """
 
-COMMANDS_HELP = """Commands: look, north, south, east, west, last, travel, class, inventory, get, drop, exit, macro, @name, do
+COMMANDS_HELP = """Commands: look, north, south, east, west, last, travel, class (or x), inventory, get, drop, exit, macro, @name, do
 
 Look
 ----
@@ -91,4 +91,3 @@ ABBREVIATIONS_NOTE = """Prefixes
   If multiple names match, the first in the list is used.
 • For LOOK specifically, a name after 'look' prefers monsters over items. If neither matches, 'look <dir>' is tried.
 """
-

--- a/tests/smoke/test_commands_and_aggro.py
+++ b/tests/smoke/test_commands_and_aggro.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import re
+import tempfile
+from pathlib import Path
+
+from mutants2.cli.shell import make_context, resolve_command
+from mutants2.engine import world as world_mod, persistence
+from mutants2.engine.player import Player
+from mutants2.testing_api import run_one
+
+
+def run_commands(cmds, *, seed: int = 42, setup=None):
+    save = persistence.Save(global_seed=seed)
+    w = world_mod.World(global_seed=seed)
+    w.year(2000)
+    p = Player(year=2000, clazz="Warrior")
+    if setup:
+        setup(w, p)
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with tempfile.TemporaryDirectory() as tmp:
+        persistence.SAVE_PATH = Path(tmp) / "save.json"
+        with contextlib.redirect_stdout(buf):
+            for c in cmds:
+                ctx.dispatch_line(c)
+    out = re.sub(r"\x1b\[[0-9;]*m", "", buf.getvalue())
+    buf.close()
+    return out, w, p, ctx
+
+
+def test_x_alias_and_help():
+    assert resolve_command("x") == "class"
+    out = run_one("help")
+    assert "class (or x)" in out
+
+
+def test_blank_enter_hint():
+    out, w, _p, _ctx = run_commands([""])
+    lines = out.strip().splitlines()
+    assert lines == ["***", "Type ? if you need assistance."]
+    assert w.turn == 0
+
+
+def test_look_reroll_yells_once():
+    def setup(w, p):
+        w.place_monster(2000, 0, 0, "mutant")
+
+    out, _w, _p, _ = run_commands(["look", "look"], seed=0, setup=setup)
+    assert out.splitlines().count("Mutant yells at you!") == 1
+
+
+def test_arrival_separators():
+    def setup(w, p):
+        w.place_monster(2000, 1, 0, "mutant")
+        w.monster_here(2000, 1, 0)["aggro"] = True
+        w.place_monster(2000, -1, 0, "mutant")
+        w.monster_here(2000, -1, 0)["aggro"] = True
+
+    out, _w, _p, _ = run_commands(["look"], setup=setup)
+    assert out.count("has just arrived") == 2
+    first = out.find("has just arrived")
+    second = out.find("has just arrived", first + 1)
+    between = out[first:second]
+    assert "***" in between
+
+
+def test_exit_resets_aggro():
+    def setup(w, p):
+        w.place_monster(2000, 1, 0, "mutant")
+        w.monster_here(2000, 1, 0)["aggro"] = True
+
+    out, w, _p, _ = run_commands(["look", "exit"], setup=setup)
+    assert "Goodbye." in out
+    assert not w.any_aggro_in_year(2000)


### PR DESCRIPTION
## Summary
- add `x` as alias for `class` and mention in help
- reroll on-tile aggro when using `look` and when starting or returning to game
- reset all monster aggro when leaving to class menu or exiting
- show hint on blank input and separate multiple arrivals with `***`

## Testing
- `pytest tests/smoke/test_commands_and_aggro.py -q`
- `pytest tests/smoke -q`


------
https://chatgpt.com/codex/tasks/task_e_68b879da1a3c832b957ba01aa8faf391