### PR TITLE
Randomized room headers and boundary feedback

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -320,7 +320,7 @@ def make_context(p, w, save, *, dev: bool = False):
             moved = False
             if last_move:
                 moved = p.move(last_move, w)
-            if moved:
+            if moved or p._last_move_struck_back:
                 turn = True
             context._needs_render = True
         elif cmd == "class":
@@ -472,6 +472,7 @@ def make_context(p, w, save, *, dev: bool = False):
             moved = p.move(cmd, w)
             if moved:
                 last_move = cmd
+            if moved or p._last_move_struck_back:
                 turn = True
             context._needs_render = True
         elif cmd == "travel":

--- a/mutants2/data/__init__.py
+++ b/mutants2/data/__init__.py
@@ -1,0 +1,1 @@
+# data package for mutants2

--- a/mutants2/data/room_headers.py
+++ b/mutants2/data/room_headers.py
@@ -1,0 +1,20 @@
+ROOM_HEADERS = [
+  "A sign reads: FOR SALE $ 350000",
+  "You see rubble everywhere.",
+  "You feel a cold breeze.",
+  "The street is cracked here.",
+  "Broken lamp posts line the streets.",
+  "The wind is whistling through open windows.",
+  "You're in an abandoned building.",
+  "An eerie calm settles in the distance.",
+  "You're in a maintenance shop.",
+  "You're in a wrecked building.",
+  "Crumbling buildings surround you.",
+  "Relics of the war line the streets.",
+  "The two moons are rising above.",
+  "An old hydro line has fallen here.",
+  "You hear volcanoes erupt in the distance.",
+  "Graffiti lines the city walls.",
+  "Broken glass covers the road.",
+  "City Trading Centre."
+]

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -5,6 +5,7 @@ from typing import Dict, Tuple
 
 from .senses import SensesBuffer
 from . import items as items_mod
+from ..ui.theme import red
 
 
 # Available player classes. These are simple placeholders for now and do not
@@ -27,6 +28,7 @@ class Player:
     inventory: Dict[str, int] = field(default_factory=dict)
     hp: int = 10
     max_hp: int = 10
+    _last_move_struck_back: bool = field(default=False, repr=False)
 
     @property
     def x(self) -> int:
@@ -38,6 +40,7 @@ class Player:
 
     def move(self, direction: str, world) -> bool:
         x, y = self.positions.setdefault(self.year, (0, 0))
+        self._last_move_struck_back = False
         if direction not in {"north", "south", "east", "west"}:
             print("can't go that way.")
             return False
@@ -45,7 +48,8 @@ class Player:
             nx, ny = world.step(x, y, direction)
             self.positions[self.year] = (nx, ny)
             return True
-        print("can't go that way.")
+        self._last_move_struck_back = True
+        print(red("You are struck back."))
         return False
 
     def travel(self, world, target_year: int | None = None) -> None:

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import random
 from dataclasses import dataclass
 from typing import Dict, Tuple, Set, Optional, Iterable, Iterator
 
 from .senses import Direction
 from . import monsters as monsters_mod, items as items_mod
+from ..data.room_headers import ROOM_HEADERS
 
 Coordinate = Tuple[int, int]
 
@@ -142,6 +144,7 @@ class World:
         self.global_seed = global_seed
         self._recent_monster_moves: list[tuple[int, int, int, int, int]] = []
         self.turn = turn
+        self._room_headers: Dict[Tuple[int, int, int], str] = {}
 
     def ground_item(self, year: int, x: int, y: int) -> Optional[str]:
         items = self.ground.get((year, x, y))
@@ -180,6 +183,16 @@ class World:
     def items_on_ground(self, year: int, x: int, y: int) -> list[items_mod.ItemDef]:
         keys = self.ground.get((year, x, y), [])
         return [items_mod.REGISTRY[k] for k in keys]
+
+    def room_description(self, year: int, x: int, y: int) -> str:
+        """Return the room header for the given tile, generating on demand."""
+        key = (year, x, y)
+        header = self._room_headers.get(key)
+        if header is None:
+            rng = random.Random(hash((self.global_seed, year, x, y, "room_header_v1")))
+            header = rng.choice(ROOM_HEADERS)
+            self._room_headers[key] = header
+        return header
 
     # Helpers for daily top-up -------------------------------------------------
 

--- a/tests/smoke/test_room_headers_and_boundary.py
+++ b/tests/smoke/test_room_headers_and_boundary.py
@@ -1,0 +1,43 @@
+import contextlib
+from io import StringIO
+
+from mutants2.engine.world import World, GRID_MIN
+from mutants2.engine.player import Player
+from mutants2.render import render_current_room
+from mutants2.data.room_headers import ROOM_HEADERS
+from mutants2.ui.theme import red
+
+
+def capture_room(w, p):
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        print(render_current_room(p, w))
+    return buf.getvalue().splitlines()
+
+
+def test_headers_deterministic():
+    w = World(global_seed=123)
+    p = Player()
+    h1 = w.room_description(p.year, p.x, p.y)
+    h2 = w.room_description(p.year, p.x, p.y)
+    assert h1 == h2
+    h3 = w.room_description(p.year, p.x + 1, p.y)
+    assert h1 in ROOM_HEADERS and h3 in ROOM_HEADERS
+    lines = capture_room(w, p)
+    assert lines[0] == red(h1)
+
+
+def test_struck_back_boundary():
+    w = World()
+    p = Player()
+    p.positions[p.year] = (GRID_MIN, 0)
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        moved = p.move("west", w)
+        print(render_current_room(p, w))
+    out = buf.getvalue().splitlines()
+    assert moved is False
+    assert p._last_move_struck_back
+    assert "struck back" in out[0].lower()
+    assert (p.x, p.y) == (GRID_MIN, 0)
+    assert out[1] in {red(h) for h in ROOM_HEADERS}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,7 +29,7 @@ def test_blocked_move_still_renders_room(tmp_path):
     cmds = ['west'] * 16 + ['exit']
     result = _run_game(cmds, tmp_path)
     assert result.returncode == 0
-    assert "can't go that way." in result.stdout
+    assert "struck back" in result.stdout.lower()
     # Final render after hitting west edge
     assert result.stdout.count('Compass: (-15E : 0N)') >= 1
 


### PR DESCRIPTION
## Summary
- Add original room header pool and assign deterministic random header per room
- Display red "You are struck back." when attempting to leave map boundaries
- Treat boundary collisions as turns and update tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8884eea60832bb95622deaef9d74b