### PR TITLE
refactor: improve type safety for maps and directions

### DIFF
--- a/mutants2/__main__.py
+++ b/mutants2/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import os
 import atexit
@@ -27,11 +29,14 @@ def main() -> None:
 
     from mutants2.cli.shell import make_context, class_menu
     from mutants2.engine import persistence, world as world_mod
+    from mutants2.engine.types import MonsterRec, TileKey
     from mutants2.engine.render import render_room_view
     from mutants2.engine.gen import daily_topup_if_needed
 
     p, ground, monsters, seeded, save = persistence.load()
-    w = world_mod.World(ground, seeded, monsters, global_seed=save.global_seed)
+    ground_map: dict[TileKey, list[str]] = ground
+    monsters_map: dict[TileKey, list[MonsterRec]] = monsters
+    w = world_mod.World(ground_map, seeded, monsters_map, global_seed=save.global_seed)
 
     if p.clazz is None:
         w.reset_all_aggro()

--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 import datetime
+from typing import Mapping, cast
 
 from ..engine import persistence, items, monsters
 from ..engine.render import render_room_view
@@ -9,6 +10,7 @@ from ..engine import render as render_mod
 from ..engine.player import CLASS_LIST, CLASS_BY_NUM, CLASS_BY_NAME
 from ..engine.gen import daily_topup_if_needed
 from ..engine.macros import MacroStore
+from ..engine.types import Direction
 from ..ui.help import MACROS_HELP, ABBREVIATIONS_NOTE, COMMANDS_HELP
 from ..ui.strings import GET_WHAT, DROP_WHAT
 from ..ui.theme import red, SEP
@@ -48,18 +50,23 @@ TURN_CMDS = {
     "look",
 }
 
-DIR_FULL = ("north", "south", "east", "west")
-DIR_1 = {"n": "north", "s": "south", "e": "east", "w": "west"}
+DIR_FULL: tuple[Direction, ...] = ("north", "south", "east", "west")
+DIR_1: Mapping[str, Direction] = {
+    "n": "north",
+    "s": "south",
+    "e": "east",
+    "w": "west",
+}
 
 
-def parse_dir_any_prefix(tok: str) -> str | None:
+def parse_dir_any_prefix(tok: str) -> Direction | None:
     """Return a direction if tok is 1..full prefix of exactly one dir."""
     t = tok.strip().lower()
     if not t:
         return None
     if t in DIR_1:
         return DIR_1[t]
-    matches = [d for d in DIR_FULL if d.startswith(t)]
+    matches: list[Direction] = [d for d in DIR_FULL if d.startswith(t)]
     if len(matches) == 1:
         return matches[0]
     return None
@@ -439,7 +446,7 @@ def make_context(p, w, save, *, dev: bool = False):
                 elif args and args[0] == "shadow" and len(args) == 2:
                     direction = args[1]
                     if direction in {"north", "south", "east", "west"}:
-                        p.senses.add_shadow(direction)
+                        p.senses.add_shadow(cast(Direction, direction))
                         print("OK.")
                     else:
                         print("Invalid direction.")

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Tuple
+from typing import Dict, Tuple, cast
 
 from .senses import SensesBuffer
+from .types import Direction
 from . import items as items_mod
 from ..ui.theme import red
 
@@ -44,8 +45,9 @@ class Player:
         if direction not in {"north", "south", "east", "west"}:
             print("can't go that way.")
             return False
-        if world.is_open(self.year, x, y, direction):
-            nx, ny = world.step(x, y, direction)
+        d = cast(Direction, direction)
+        if world.is_open(self.year, x, y, d):
+            nx, ny = world.step(x, y, d)
             self.positions[self.year] = (nx, ny)
             return True
         self._last_move_struck_back = True

--- a/mutants2/engine/senses.py
+++ b/mutants2/engine/senses.py
@@ -1,7 +1,9 @@
-from dataclasses import dataclass, field
-from typing import Optional, Set, Literal
+from __future__ import annotations
 
-Direction = Literal["north", "south", "east", "west"]
+from dataclasses import dataclass, field
+from typing import Optional, Set
+
+from .types import Direction
 
 
 @dataclass

--- a/mutants2/engine/types.py
+++ b/mutants2/engine/types.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from typing import Mapping, MutableMapping, Sequence, Tuple, Literal
+
+TileKey = Tuple[int, int, int]
+Direction = Literal["north", "south", "east", "west"]
+ItemList = Sequence[str]
+ItemListMut = list[str]
+MonsterRec = Mapping[str, object]
+MonsterList = Sequence[MonsterRec]
+
+
+def mk_key(x: int, y: int, year: int) -> TileKey:
+    return (x, y, year)

--- a/tests/test_combat_minimal.py
+++ b/tests/test_combat_minimal.py
@@ -12,7 +12,7 @@ def world_with_mutant_on_start(tmp_path):
     persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
     os.environ['HOME'] = str(tmp_path)
     p = Player()
-    w = World(monsters={(2000, 0, 0): {'key': 'mutant', 'hp': 3}}, seeded_years={2000})
+    w = World(monsters={(2000, 0, 0): [{'key': 'mutant', 'hp': 3}]}, seeded_years={2000})
     save = persistence.Save()
     persistence.save(p, w, save)
     return None
@@ -42,7 +42,7 @@ def test_retaliation_and_death_respawn(world_with_mutant_on_start, cli_runner):
     persistence.SAVE_PATH = save_path
     p = Player()
     p.max_hp = p.hp = 1
-    w = World(monsters={(2000, 0, 0): {'key': 'mutant', 'hp': 3}}, seeded_years={2000})
+    w = World(monsters={(2000, 0, 0): [{'key': 'mutant', 'hp': 3}]}, seeded_years={2000})
     save = persistence.Save()
     persistence.save(p, w, save)
     out2 = cli_runner.run_commands(["att", "att", "att", "att"])

--- a/tests/test_commands_abbrev.py
+++ b/tests/test_commands_abbrev.py
@@ -13,7 +13,7 @@ from mutants2.engine.player import Player
 @pytest.fixture
 def seeded_world_with_item(tmp_path):
     persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
-    w = World({(2000, 0, 0): 'ion_decay'}, {2000})
+    w = World({(2000, 0, 0): ['ion_decay']}, {2000})
     p = Player()
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()

--- a/tests/test_items_basic.py
+++ b/tests/test_items_basic.py
@@ -30,7 +30,7 @@ def test_pickup_and_drop_roundtrip(tmp_path):
     persistence.SAVE_PATH = Path(tmp_path) / '.mutants2' / 'save.json'
     os.environ['HOME'] = str(tmp_path)
     p = Player()
-    w = World({(2000, 0, 0): 'ion_decay'}, {2000})
+    w = World({(2000, 0, 0): ['ion_decay']}, {2000})
     save = persistence.Save()
     persistence.save(p, w, save)
     result = _run_game(['get Ion-Decay', 'look', 'inventory', 'drop Ion-Decay', 'look', 'inventory', 'exit'], tmp_path)
@@ -60,7 +60,7 @@ def test_persistence_inventory_and_ground(tmp_path):
     persistence.SAVE_PATH = Path(tmp_path) / '.mutants2' / 'save.json'
     os.environ['HOME'] = str(tmp_path)
     p = Player()
-    w = World({(2000, 0, 0): 'ion_decay'}, {2000})
+    w = World({(2000, 0, 0): ['ion_decay']}, {2000})
     save = persistence.Save()
     persistence.save(p, w, save)
     _run_game(['get Ion-Decay', 'east', 'exit'], tmp_path)
@@ -74,7 +74,7 @@ def test_name_matching_case_insensitive(tmp_path):
     persistence.SAVE_PATH = Path(tmp_path) / '.mutants2' / 'save.json'
     os.environ['HOME'] = str(tmp_path)
     p = Player()
-    w = World({(2000, 0, 0): 'ion_decay'}, {2000})
+    w = World({(2000, 0, 0): ['ion_decay']}, {2000})
     save = persistence.Save()
     persistence.save(p, w, save)
     result = _run_game(['get ion-decay', 'drop ion-decay', 'get Ion-Decay', 'inventory', 'exit'], tmp_path)

--- a/tests/test_items_prefix_and_abbrev.py
+++ b/tests/test_items_prefix_and_abbrev.py
@@ -12,7 +12,7 @@ def tile_with_item(tmp_path):
     persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
     os.environ['HOME'] = str(tmp_path)
     p = Player()
-    w = World({(2000, 0, 0): 'nuclear_thong'}, {2000})
+    w = World({(2000, 0, 0): ['nuclear_thong']}, {2000})
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()
     persistence.save(p, w, save)

--- a/tests/test_ui_parity.py
+++ b/tests/test_ui_parity.py
@@ -26,7 +26,7 @@ def test_single_item_and_stack():
 
 
 def test_render_order_and_copy():
-    w = World({(2000, 0, 0): "ion_decay"}, {2000})
+    w = World({(2000, 0, 0): ["ion_decay"]}, {2000})
     w.place_monster(2000, 0, 0, "mutant")
     w.place_monster(2000, 1, 0, "mutant")
     out = strip_ansi(render_room_at(w, 2000, 0, 0))


### PR DESCRIPTION
## Summary
- add central type aliases for tile keys, direction and game records
- make world and persistence use Mapping-based ground/monster stores
- validate direction inputs and cast user input before use

## Testing
- `pyright mutants2 --level warning`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b8906280b0832b8fb996f482e4cf96