### PR TITLE
Suppress room render on off-grid moves

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -327,6 +327,8 @@ def make_context(p, w, save, *, dev: bool = False):
             moved = False
             if last_move:
                 moved = p.move(last_move, w)
+                if p._last_move_struck_back:
+                    context._suppress_room_render = True
             if moved or p._last_move_struck_back:
                 turn = True
             context._needs_render = True
@@ -479,6 +481,8 @@ def make_context(p, w, save, *, dev: bool = False):
             moved = p.move(cmd, w)
             if moved:
                 last_move = cmd
+            if p._last_move_struck_back:
+                context._suppress_room_render = True
             if moved or p._last_move_struck_back:
                 turn = True
             context._needs_render = True

--- a/tests/smoke/test_room_headers_and_boundary.py
+++ b/tests/smoke/test_room_headers_and_boundary.py
@@ -34,10 +34,9 @@ def test_struck_back_boundary():
     buf = StringIO()
     with contextlib.redirect_stdout(buf):
         moved = p.move("west", w)
-        print(render_current_room(p, w))
     out = buf.getvalue().splitlines()
     assert moved is False
     assert p._last_move_struck_back
-    assert "struck back" in out[0].lower()
     assert (p.x, p.y) == (GRID_MIN, 0)
-    assert out[1] in {red(h) for h in ROOM_HEADERS}
+    assert len(out) == 1
+    assert "struck back" in out[0].lower()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -25,13 +25,21 @@ def test_move_shows_room_after_success(tmp_path):
     assert 'Compass: (1E : 0N)' in result.stdout
 
 
-def test_blocked_move_still_renders_room(tmp_path):
+def test_blocked_move_suppresses_room(tmp_path):
     cmds = ['west'] * 16 + ['exit']
     result = _run_game(cmds, tmp_path)
     assert result.returncode == 0
     assert "struck back" in result.stdout.lower()
-    # Final render after hitting west edge
-    assert result.stdout.count('Compass: (-15E : 0N)') >= 1
+    lines = result.stdout.splitlines()
+    sb_idx = max(i for i, line in enumerate(lines) if "struck back" in line.lower())
+    after = []
+    for line in lines[sb_idx + 1:]:
+        if line.strip().lower() == 'exit' or line.strip() == 'Goodbye.':
+            break
+        after.append(line)
+    forbidden = ('Room:', 'Compass:', 'Exits:', 'Ground:', 'Presence:', 'Shadows:', '***')
+    for line in after:
+        assert not any(tok in line for tok in forbidden)
 
 
 def test_direction_aliases_one_letter(tmp_path):


### PR DESCRIPTION
## Summary
- prevent room block rendering when a move goes off the map
- show the red "You are struck back." message only
- test boundary handling and CLI output

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8a33ee604832b87ccb7278aff1a03