### PR TITLE
Ensure resident yells print before arrival lines

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -566,18 +566,20 @@ def make_context(p, w, save, *, dev: bool = False):
                 context._footsteps_event = None
             w.turn += 1
         if context._needs_render and not context._suppress_room_render:
-            render_room_view(p, w, context)
+            render_room_view(p, w, context, include_arrivals=False)
             context._needs_render = False
         elif context._suppress_room_render:
             context._needs_render = False
-            arrivals = render_mod.arrival_lines(context)
+            context._suppress_room_render = False
+        for msg in render_mod.entry_yell_lines(context):
+            print(msg)
+        arrivals = render_mod.arrival_lines(context)
+        if arrivals:
+            print(SEP)
             for i, msg in enumerate(arrivals):
                 print(red(msg))
                 if i < len(arrivals) - 1:
                     print(SEP)
-            context._suppress_room_render = False
-        for msg in render_mod.entry_yell_lines(context):
-            print(msg)
         for msg in render_mod.footsteps_lines(context):
             print(msg)
         return False

--- a/mutants2/engine/render.py
+++ b/mutants2/engine/render.py
@@ -33,7 +33,14 @@ def footsteps_lines(ctx) -> list[str]:
         return [f"You hear loud sounds of footsteps to the {d}."]
 
 
-def render_room_view(player: Player, world: World, context=None, *, consume_cues: bool = True) -> None:
+def render_room_view(
+    player: Player,
+    world: World,
+    context=None,
+    *,
+    consume_cues: bool = True,
+    include_arrivals: bool = True,
+) -> None:
     if consume_cues:
         cues = player.senses.pop()
     else:
@@ -46,6 +53,7 @@ def render_room_view(player: Player, world: World, context=None, *, consume_cues
         include_shadows=True,
         shadow_dirs_extra=cues.shadow_dirs,
         context=context,
+        include_arrivals=include_arrivals,
     )
     print(text)
 

--- a/tests/test_entry_yells_before_arrivals.py
+++ b/tests/test_entry_yells_before_arrivals.py
@@ -1,0 +1,57 @@
+import contextlib
+from io import StringIO
+
+import pytest
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence, world as world_mod, monsters as monsters_mod
+from mutants2.engine.player import Player
+
+
+@pytest.fixture
+def world():
+    w = world_mod.World()
+    w.year(2000)
+    for x, y, _ in list(w.monster_positions(2000)):
+        w.remove_monster(2000, x, y)
+    monsters_mod._next_id = 1
+    w.place_monster(2000, 0, 0, "mutant")
+    w.monster_here(2000, 0, 0)["aggro"] = True
+    w.place_monster(2000, 1, 0, "mutant")
+    return w
+
+
+@pytest.fixture
+def cli(world, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    save = persistence.Save()
+    p = Player()
+    p.clazz = "Warrior"
+    ctx = make_context(p, world, save)
+
+    def always_aggro(year, x, y, player, seed_parts=()):
+        yells = []
+        for m in world.monsters_here(year, x, y):
+            if not m.get("aggro"):
+                m["aggro"] = True
+                yells.append(f"{m['name']} yells at you!")
+        return yells
+
+    monkeypatch.setattr(world, "on_entry_aggro_check", always_aggro)
+
+    class CLI:
+        def run(self, commands):
+            buf = StringIO()
+            with contextlib.redirect_stdout(buf):
+                for cmd in commands:
+                    ctx.dispatch_line(cmd)
+            return buf.getvalue()
+
+    return CLI()
+
+
+def test_resident_yell_precedes_arrival(cli):
+    out = cli.run(["e"])
+    y_idx = out.find("yells at you")
+    a_idx = out.find("has just arrived")
+    assert y_idx != -1 and a_idx != -1 and y_idx < a_idx


### PR DESCRIPTION
## Summary
- allow room rendering to defer arrival messages
- print entry yells before arrivals and move arrivals after a separator
- add regression test covering yell/arrival ordering

## Testing
- `ruff check --fix mutants2/render.py mutants2/engine/render.py mutants2/cli/shell.py tests/test_entry_yells_before_arrivals.py`
- `black mutants2/render.py mutants2/engine/render.py mutants2/cli/shell.py tests/test_entry_yells_before_arrivals.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8a4a451a4832b93196b6f4f7f23b4