### PR TITLE
feat: add numbered monster identities

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -290,14 +290,15 @@ def make_context(p, w, save, *, dev: bool = False):
         if not m:
             print("There is nothing here to attack.")
             return
+        name = cast(str, m.get("name"))
         dead = w.damage_monster(p.year, p.x, p.y, PLAYER_DMG)
         if dead:
-            print("You defeat the Mutant.")
+            print(f"You defeat the {name}.")
             context._needs_render = False
             context._suppress_room_render = True
             return
         p.take_damage(MONSTER_DMG)
-        print(f"The Mutant hits you (-{MONSTER_DMG} HP). (HP: {p.hp}/{p.max_hp})")
+        print(f"The {name} hits you (-{MONSTER_DMG} HP). (HP: {p.hp}/{p.max_hp})")
         if p.is_dead():
             print("You have died.")
             p.heal_full()

--- a/mutants2/engine/monsters.py
+++ b/mutants2/engine/monsters.py
@@ -13,41 +13,52 @@ class MonsterDef:
 REGISTRY = {
     "mutant": MonsterDef("mutant", "Mutant", base_hp=3),
     "night_stalker": MonsterDef("night_stalker", "Night-Stalker", base_hp=3),
+    "dragon_turtle": MonsterDef("dragon_turtle", "Dragon-Turtle", base_hp=3),
+    "glabrezu_demon": MonsterDef("glabrezu_demon", "Glabrezu-Demon", base_hp=3),
+    "leucrotta": MonsterDef("leucrotta", "Leucrotta", base_hp=3),
+    "lizard_man": MonsterDef("lizard_man", "Lizard-Man", base_hp=3),
+    "evil_pegasus": MonsterDef("evil_pegasus", "Evil-Pegasus", base_hp=3),
+    "sandworm": MonsterDef("sandworm", "Sandworm", base_hp=3),
+    "umber_hulk": MonsterDef("umber_hulk", "Umber-Hulk", base_hp=3),
+    "gargoyle": MonsterDef("gargoyle", "Gargoyle", base_hp=3),
+    "kraken": MonsterDef("kraken", "Kraken", base_hp=3),
+    "opal_cockatrice": MonsterDef("opal_cockatrice", "Opal-Cockatrice", base_hp=3),
 }
 
 SPAWN_KEYS = tuple(REGISTRY.keys())
 
 
-_next_id = 1
+class MonsterIdAllocator:
+    """Allocate unique 4-digit monster ids."""
+
+    def __init__(self, rng):
+        self._free = list(range(1000, 10000))
+        rng.shuffle(self._free)
+
+    def allocate(self) -> int:
+        return self._free.pop()
+
+    def release(self, mid: int) -> None:
+        if 1000 <= mid <= 9999 and mid not in self._free:
+            self._free.append(mid)
+
+    def note_existing(self, mid: int) -> None:
+        try:
+            self._free.remove(mid)
+        except ValueError:
+            pass
 
 
-def next_id() -> int:
-    """Return a stable id for a newly spawned monster."""
-
-    global _next_id
-    nid = _next_id
-    _next_id += 1
-    return nid
-
-
-def note_existing_id(nid: int) -> None:
-    """Advance the internal counter to avoid reusing ``nid``."""
-
-    global _next_id
-    if nid >= _next_id:
-        _next_id = nid + 1
-
-
-def spawn(key: str, year: int, x: int, y: int) -> dict:
+def spawn(key: str, mid: int) -> dict:
     """Return default data for a newly spawned monster."""
 
-    counter = next_id()
+    name = f"{REGISTRY[key].name}-{mid:04d}"
     return {
         "key": key,
-        "name": REGISTRY[key].name,
+        "name": name,
         "aggro": False,
         "seen": False,
-        "id": counter,
+        "id": mid,
         "hp": REGISTRY[key].base_hp,
     }
 

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -50,7 +50,9 @@ def load() -> tuple[
         player.positions.update(positions)
         player.max_hp = int(data.get("max_hp", player.max_hp))
         player.hp = int(data.get("hp", player.max_hp))
-        player.inventory.update({k: int(v) for k, v in data.get("inventory", {}).items()})
+        player.inventory.update(
+            {k: int(v) for k, v in data.get("inventory", {}).items()}
+        )
         ground: dict[TileKey, ItemListMut] = {}
         for key, val in data.get("ground", {}).items():
             parts = [int(n) for n in key.split(",")]
@@ -75,18 +77,15 @@ def load() -> tuple[
                 seen = entry.get("seen", False)
                 mid = entry.get("id")
                 base = monsters_mod.REGISTRY[m_key].base_hp
-                if mid is None:
-                    mid = monsters_mod.next_id()
-                else:
-                    monsters_mod.note_existing_id(int(mid))
                 m: dict[str, object] = {
                     "key": m_key,
                     "hp": int(hp) if hp is not None else base,
                     "name": name or monsters_mod.REGISTRY[m_key].name,
                     "aggro": bool(aggro),
                     "seen": bool(seen),
-                    "id": int(mid),
                 }
+                if mid is not None:
+                    m["id"] = int(mid)
                 if m.get("aggro") and not m.get("seen"):
                     m["aggro"] = False
                 lst.append(m)
@@ -104,7 +103,11 @@ def load() -> tuple[
         monsters_data: dict[TileKey, list[MonsterRec]] = {}
         seeded: Set[int] = set()
         save_meta = Save()
-        save(player, World(ground, seeded, monsters_data, global_seed=save_meta.global_seed), save_meta)
+        save(
+            player,
+            World(ground, seeded, monsters_data, global_seed=save_meta.global_seed),
+            save_meta,
+        )
         return player, ground, monsters_data, seeded, save_meta
 
 
@@ -114,8 +117,7 @@ def save(player: Player, world: World, save_meta: Save) -> None:
         data = {
             "year": player.year,
             "positions": {
-                str(y): {"x": x, "y": yy}
-                for y, (x, yy) in player.positions.items()
+                str(y): {"x": x, "y": yy} for y, (x, yy) in player.positions.items()
             },
             "class": player.clazz,
             "hp": player.hp,
@@ -126,9 +128,7 @@ def save(player: Player, world: World, save_meta: Save) -> None:
                 for (y, x, yy), items in world.ground.items()
             },
             "monsters": {
-                f"{y},{x},{yy}": (
-                    processed[0] if len(processed) == 1 else processed
-                )
+                f"{y},{x},{yy}": (processed[0] if len(processed) == 1 else processed)
                 for (y, x, yy), lst in world.monsters.items()
                 for processed in [
                     [

--- a/tests/smoke/test_commands_and_aggro.py
+++ b/tests/smoke/test_commands_and_aggro.py
@@ -49,7 +49,7 @@ def test_look_reroll_yells_once():
         w.place_monster(2000, 0, 0, "mutant")
 
     out, _w, _p, _ = run_commands(["look", "look"], seed=0, setup=setup)
-    assert out.splitlines().count("Mutant yells at you!") <= 1
+    assert sum(1 for ln in out.splitlines() if "yells at you!" in ln) <= 1
 
 
 def test_arrival_separators():

--- a/tests/smoke/test_compass_and_ui.py
+++ b/tests/smoke/test_compass_and_ui.py
@@ -59,11 +59,11 @@ def test_resident_and_arrival_rendering():
     out = re.sub(r"\x1b\[[0-9;]*m", "", buf.getvalue())
     buf.close()
     assert out.splitlines().count("look") == 1
-    assert "Night-Stalker is here" in out
-    assert "Mutant is here" not in out
+    assert re.search(r"Night-Stalker-\d{4} is here", out)
+    assert not re.search(r"Mutant-\d{4} is here", out)
     assert "You see shadows" in out
     assert out.count("has just arrived from") == 1
-    presence_idx = out.find("Night-Stalker is here")
+    presence_idx = re.search(r"Night-Stalker-\d{4} is here", out).start()
     shadow_idx = out.find("You see shadows")
     arrival_idx = out.find("has just arrived from")
     assert presence_idx < shadow_idx < arrival_idx

--- a/tests/smoke/test_errant_and_attack_rendering.py
+++ b/tests/smoke/test_errant_and_attack_rendering.py
@@ -2,8 +2,12 @@ from mutants2.cli.shell import make_context
 from mutants2.engine import world as world_mod, persistence
 from mutants2.engine.player import Player
 
-import io, contextlib, tempfile, re
+import io
+import contextlib
+import tempfile
+import re
 from pathlib import Path
+
 
 def run_commands(cmds, *, seed=42, setup=None):
     save = persistence.Save(global_seed=seed)
@@ -30,10 +34,11 @@ def test_attack_no_room_block_but_arrival():
         w.monster_here(2000, 0, 0)["hp"] = 2
         w.place_monster(2000, 1, 0, "mutant")
         w.monster_here(2000, 1, 0)["aggro"] = True
+
     out, w, _p, _ = run_commands(["attack"], setup=setup)
     assert "You are here." not in out
     assert "Compass:" not in out
-    assert "You defeat the Mutant." in out
+    assert re.search(r"You defeat the Mutant-\d{4}\.", out)
     assert "has just arrived from the west." in out
 
 

--- a/tests/test_aggro_on_entry.py
+++ b/tests/test_aggro_on_entry.py
@@ -4,7 +4,7 @@ import contextlib
 import pytest
 
 from mutants2.cli.shell import make_context
-from mutants2.engine import persistence, world as world_mod, monsters as monsters_mod
+from mutants2.engine import persistence, world as world_mod
 from mutants2.engine.player import Player
 
 
@@ -14,7 +14,6 @@ def world_with_passive_mutant_here(seeded_rng):
     w.year(2000)
     for x, y, _ in list(w.monster_positions(2000)):
         w.remove_monster(2000, x, y)
-    monsters_mod._next_id = 1
     w.place_monster(2000, 0, 0, "mutant")  # passive by default
     return w
 
@@ -40,8 +39,9 @@ def cli(world_with_passive_mutant_here, tmp_path, monkeypatch):
 
 @pytest.fixture
 def seeded_rng(monkeypatch):
-    import hashlib, random
-    from mutants2.engine import rng, monsters as monsters_mod
+    import hashlib
+    import random
+    from mutants2.engine import rng
 
     def fake_hrand(*parts):
         h = hashlib.md5(str(parts).encode()).hexdigest()
@@ -49,7 +49,6 @@ def seeded_rng(monkeypatch):
         return random.Random(seed)
 
     monkeypatch.setattr(rng, "hrand", fake_hrand)
-    monsters_mod._next_id = 1
 
 
 def test_on_entry_rolls(cli, world_with_passive_mutant_here, seeded_rng):
@@ -57,4 +56,3 @@ def test_on_entry_rolls(cli, world_with_passive_mutant_here, seeded_rng):
     assert "yells at you" not in out.lower()
     out2 = cli.run(["n", "s"])
     assert "yells at you" in out2.lower()
-

--- a/tests/test_audio_movement_only.py
+++ b/tests/test_audio_movement_only.py
@@ -10,8 +10,9 @@ from mutants2.engine.player import Player
 
 @pytest.fixture
 def seeded_rng(monkeypatch):
-    import hashlib, random
-    from mutants2.engine import rng, monsters as monsters_mod
+    import hashlib
+    import random
+    from mutants2.engine import rng
 
     def fake_hrand(*parts):
         h = hashlib.md5(str(parts).encode()).hexdigest()
@@ -19,7 +20,6 @@ def seeded_rng(monkeypatch):
         return random.Random(seed)
 
     monkeypatch.setattr(rng, "hrand", fake_hrand)
-    monsters_mod._next_id = 1
 
 
 @pytest.fixture

--- a/tests/test_combat_minimal.py
+++ b/tests/test_combat_minimal.py
@@ -2,6 +2,8 @@ import os
 import pytest
 
 from mutants2.engine import persistence
+import re
+
 from mutants2.engine.world import World
 from mutants2.engine.player import Player
 from pathlib import Path
@@ -9,10 +11,12 @@ from pathlib import Path
 
 @pytest.fixture
 def world_with_mutant_on_start(tmp_path):
-    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
-    os.environ['HOME'] = str(tmp_path)
+    persistence.SAVE_PATH = tmp_path / ".mutants2" / "save.json"
+    os.environ["HOME"] = str(tmp_path)
     p = Player()
-    w = World(monsters={(2000, 0, 0): [{'key': 'mutant', 'hp': 3}]}, seeded_years={2000})
+    w = World(
+        monsters={(2000, 0, 0): [{"key": "mutant", "hp": 3}]}, seeded_years={2000}
+    )
     save = persistence.Save()
     persistence.save(p, w, save)
     return None
@@ -20,8 +24,8 @@ def world_with_mutant_on_start(tmp_path):
 
 @pytest.fixture
 def empty_start_world(tmp_path):
-    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
-    os.environ['HOME'] = str(tmp_path)
+    persistence.SAVE_PATH = tmp_path / ".mutants2" / "save.json"
+    os.environ["HOME"] = str(tmp_path)
     p = Player()
     w = World(seeded_years={2000})
     save = persistence.Save()
@@ -31,18 +35,20 @@ def empty_start_world(tmp_path):
 
 def test_attack_kills_with_few_hits(world_with_mutant_on_start, cli_runner):
     out = cli_runner.run_commands(["att", "att"])
-    assert "You defeat the Mutant" in out
+    assert re.search(r"You defeat the Mutant-\d{4}", out)
 
 
 def test_retaliation_and_death_respawn(world_with_mutant_on_start, cli_runner):
     out = cli_runner.run_commands(["att"])
-    assert "The Mutant hits you" in out
+    assert re.search(r"The Mutant-\d{4} hits you", out)
     # reset world with low player HP for death test
-    save_path = Path(os.environ["HOME"]) / '.mutants2' / 'save.json'
+    save_path = Path(os.environ["HOME"]) / ".mutants2" / "save.json"
     persistence.SAVE_PATH = save_path
     p = Player()
     p.max_hp = p.hp = 1
-    w = World(monsters={(2000, 0, 0): [{'key': 'mutant', 'hp': 3}]}, seeded_years={2000})
+    w = World(
+        monsters={(2000, 0, 0): [{"key": "mutant", "hp": 3}]}, seeded_years={2000}
+    )
     save = persistence.Save()
     persistence.save(p, w, save)
     out2 = cli_runner.run_commands(["att", "att", "att", "att"])
@@ -67,4 +73,4 @@ def test_status_shows_hp_and_coords(empty_start_world, cli_runner):
 
 def test_room_line_shows_monster_present(world_with_mutant_on_start, cli_runner):
     out = cli_runner.run_commands(["loo"])
-    assert "Mutant" in out and "is here" in out
+    assert re.search(r"Mutant-\d{4}.*is here", out)

--- a/tests/test_entry_yells_before_arrivals.py
+++ b/tests/test_entry_yells_before_arrivals.py
@@ -4,7 +4,7 @@ from io import StringIO
 import pytest
 
 from mutants2.cli.shell import make_context
-from mutants2.engine import persistence, world as world_mod, monsters as monsters_mod
+from mutants2.engine import persistence, world as world_mod
 from mutants2.engine.player import Player
 
 
@@ -14,7 +14,6 @@ def world():
     w.year(2000)
     for x, y, _ in list(w.monster_positions(2000)):
         w.remove_monster(2000, x, y)
-    monsters_mod._next_id = 1
     w.place_monster(2000, 0, 0, "mutant")
     w.monster_here(2000, 0, 0)["aggro"] = True
     w.place_monster(2000, 1, 0, "mutant")

--- a/tests/test_monster_identity.py
+++ b/tests/test_monster_identity.py
@@ -1,0 +1,28 @@
+from mutants2.engine.world import World
+
+
+def test_monster_ids_unique_and_reusable():
+    w = World()
+    w.year(2000)
+    # clear any default monsters
+    for x, y, _ in list(w.monster_positions(2000)):
+        w.remove_monster(2000, x, y)
+
+    w.place_monster(2000, 0, 0, "mutant")
+    w.place_monster(2000, 1, 0, "gargoyle")
+
+    m1 = w.monster_here(2000, 0, 0)
+    m2 = w.monster_here(2000, 1, 0)
+
+    n1 = m1["id"]
+    n2 = m2["id"]
+    assert n1 != n2 and 1000 <= n1 <= 9999 and 1000 <= n2 <= 9999
+    assert m1["name"] == f"Mutant-{n1:04d}"
+    assert m2["name"] == f"Gargoyle-{n2:04d}"
+
+    # kill first monster, its number should be reusable
+    w.damage_monster(2000, 0, 0, 99)
+    w.place_monster(2000, 2, 0, "kraken")
+    m3 = w.monster_here(2000, 2, 0)
+    assert m3["id"] == n1
+    assert m3["name"] == f"Kraken-{n1:04d}"

--- a/tests/test_move_only_when_aggro.py
+++ b/tests/test_move_only_when_aggro.py
@@ -10,8 +10,9 @@ from mutants2.engine.player import Player
 
 @pytest.fixture
 def seeded_rng(monkeypatch):
-    import hashlib, random
-    from mutants2.engine import rng, monsters as monsters_mod
+    import hashlib
+    import random
+    from mutants2.engine import rng
 
     def fake_hrand(*parts):
         h = hashlib.md5(str(parts).encode()).hexdigest()
@@ -19,7 +20,6 @@ def seeded_rng(monkeypatch):
         return random.Random(seed)
 
     monkeypatch.setattr(rng, "hrand", fake_hrand)
-    monsters_mod._next_id = 1
 
 
 @pytest.fixture

--- a/tests/test_no_preaggro_after_travel.py
+++ b/tests/test_no_preaggro_after_travel.py
@@ -10,8 +10,9 @@ from mutants2.engine.player import Player
 
 @pytest.fixture
 def seeded_rng(monkeypatch):
-    import hashlib, random
-    from mutants2.engine import rng, monsters as monsters_mod
+    import hashlib
+    import random
+    from mutants2.engine import rng
 
     def fake_hrand(*parts):
         h = hashlib.md5(str(parts).encode()).hexdigest()
@@ -19,7 +20,6 @@ def seeded_rng(monkeypatch):
         return random.Random(seed)
 
     monkeypatch.setattr(rng, "hrand", fake_hrand)
-    monsters_mod._next_id = 1
 
 
 @pytest.fixture

--- a/tests/test_passive_vs_aggro_movement.py
+++ b/tests/test_passive_vs_aggro_movement.py
@@ -4,7 +4,7 @@ import contextlib
 import pytest
 
 from mutants2.cli.shell import make_context
-from mutants2.engine import persistence, world as world_mod, monsters as monsters_mod
+from mutants2.engine import persistence, world as world_mod
 from mutants2.engine.player import Player
 
 
@@ -14,7 +14,6 @@ def world_with_passive_here(seeded_rng):
     w.year(2000)
     for x, y, _ in list(w.monster_positions(2000)):
         w.remove_monster(2000, x, y)
-    monsters_mod._next_id = 1
     w.place_monster(2000, 0, 0, "mutant")  # passive by default
     return w
 
@@ -40,8 +39,9 @@ def cli(world_with_passive_here, tmp_path, monkeypatch):
 
 @pytest.fixture
 def seeded_rng(monkeypatch):
-    import hashlib, random
-    from mutants2.engine import rng, monsters as monsters_mod
+    import hashlib
+    import random
+    from mutants2.engine import rng
 
     def fake_hrand(*parts):
         h = hashlib.md5(str(parts).encode()).hexdigest()
@@ -49,7 +49,6 @@ def seeded_rng(monkeypatch):
         return random.Random(seed)
 
     monkeypatch.setattr(rng, "hrand", fake_hrand)
-    monsters_mod._next_id = 1
 
 
 def test_passive_monsters_do_not_move(cli, seeded_rng):
@@ -59,4 +58,3 @@ def test_passive_monsters_do_not_move(cli, seeded_rng):
     assert "yells at you" in out2.lower()
     out3 = cli.run(["n"])  # move away so aggro monster chases
     assert "has just arrived" in out3.lower()
-

--- a/tests/test_ui_parity.py
+++ b/tests/test_ui_parity.py
@@ -2,7 +2,6 @@ import re
 
 from mutants2.render import render_room_at
 from mutants2.engine.world import World
-from mutants2.engine.player import Player
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
@@ -39,7 +38,7 @@ def test_render_order_and_copy():
     # separators and sections order
     idxs = [i for i, ln in enumerate(lines) if ln == "***"]
     assert idxs and lines[idxs[0] - 2] == "On the ground lies:"
-    assert "Mutant is here." in lines[idxs[0] + 1]
+    assert re.search(r"Mutant-\d{4} is here\.", lines[idxs[0] + 1])
     assert len(idxs) > 1 and "You see shadows to the" in lines[idxs[1] + 1]
     assert lines[-1].startswith("You see shadows to the")
     assert "Class:" not in out


### PR DESCRIPTION
## Summary
- add many new monster species and suffix them with unique IDs
- reuse freed monster numbers via deterministic allocator
- show numbered monster names in combat and other interactions

## Testing
- `pytest -q`
- `pre-commit run --files mutants2/engine/monsters.py mutants2/engine/world.py mutants2/engine/persistence.py mutants2/cli/shell.py tests/test_audio_movement_only.py tests/test_move_only_when_aggro.py tests/test_passive_vs_aggro_movement.py tests/test_no_preaggro_after_travel.py tests/test_entry_yells_before_arrivals.py tests/test_aggro_on_entry.py tests/test_ui_parity.py tests/test_combat_minimal.py tests/smoke/test_errant_and_attack_rendering.py tests/smoke/test_commands_and_aggro.py tests/smoke/test_compass_and_ui.py tests/test_monster_identity.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*


------
https://chatgpt.com/codex/tasks/task_e_68b8a70c2f88832bb74c477f14701e6f