### PR TITLE
Add weights and ion values to item catalog

### DIFF
--- a/mutants2/engine/items.py
+++ b/mutants2/engine/items.py
@@ -8,7 +8,8 @@ import collections
 class ItemDef:
     key: str
     name: str
-    ions: Optional[int] = None
+    weight_lbs: Optional[int] = None
+    ion_value: Optional[int] = None
     riblets: Optional[int] = None
     tags: tuple[str, ...] = ()
 
@@ -16,24 +17,24 @@ class ItemDef:
 REGISTRY: dict[str, ItemDef] = {}
 
 
-def _add(key, name, ions=None, riblets=None, tags=("spawnable",)):
-    REGISTRY[key] = ItemDef(key, name, ions, riblets, tags)
+def _add(key, name, weight_lbs=None, ion_value=None, riblets=None, tags=("spawnable",)):
+    REGISTRY[key] = ItemDef(key, name, weight_lbs, ion_value, riblets, tags)
 
 
 # Populate spawnable items
-_add("nuclear_decay",  "Nuclear-Decay", 85000, 60600)
-_add("ion_decay",      "Ion-Decay",     18000, 19140)
-_add("nuclear_rock",   "Nuclear-Rock",  15000, 49200)
-_add("gold_chunk",     "Gold-Chunk",    25000, 49800)
-_add("cheese",         "Cheese",        12000, 6060)
-_add("light_spear",    "Light-Spear",   None,  None)
-_add("monster_bait",   "Monster-Bait",  None,  None)
-_add("nuclear_thong",  "Nuclear-thong", 13000, 600)
-_add("ion_pack",       "Ion-Pack",      20000, 6)
-_add("ion_booster",    "Ion-Booster",   13000, 300)
-_add("nuclear_waste",  "Nuclear-Waste", 15000, 55200)
-_add("cigarette_butt", "Cigarette-Butt",11000, 606)
-_add("bottle_cap",     "Bottle-Cap",    22000, 606)
+_add("nuclear_decay", "Nuclear-Decay", 50, 85000, 60600)
+_add("ion_decay", "Ion-Decay", 10, 18000, 19140)
+_add("nuclear_rock", "Nuclear-Rock", 10, 15000, 49200)
+_add("gold_chunk", "Gold-Chunk", 25, 25000, 49800)
+_add("cheese", "Cheese", 1, 12000, 6060)
+_add("light_spear", "Light-Spear", 10, 11000, None)
+_add("monster_bait", "Monster-Bait", None, None)
+_add("nuclear_thong", "Nuclear-thong", 20, 13000, 600)
+_add("ion_pack", "Ion-Pack", 50, 20000, 6)
+_add("ion_booster", "Ion-Booster", 10, 13000, 300)
+_add("nuclear_waste", "Nuclear-Waste", 30, 15000, 55200)
+_add("cigarette_butt", "Cigarette-Butt", 1, 11000, 606)
+_add("bottle_cap", "Bottle-Cap", 1, 22000, 606)
 
 SPAWNABLE_KEYS = [k for k, v in REGISTRY.items() if "spawnable" in v.tags]
 
@@ -81,7 +82,9 @@ def first_prefix_match(prefix: str, names_in_order: list[str]) -> str | None:
     return None
 
 
-def resolve_item_prefix(query: str, candidates: list[str]) -> tuple[Optional[str], list[str]]:
+def resolve_item_prefix(
+    query: str, candidates: list[str]
+) -> tuple[Optional[str], list[str]]:
     """Resolve ``query`` against ``candidates`` by prefix.
 
     Returns a tuple of ``(match, ambiguous)`` where ``match`` is the matched
@@ -101,7 +104,9 @@ def resolve_item_prefix(query: str, candidates: list[str]) -> tuple[Optional[str
     return None, matches[:6]
 
 
-def resolve_prefix(query: str, ground_names: list[str], inv_names: list[str]) -> Optional[str]:
+def resolve_prefix(
+    query: str, ground_names: list[str], inv_names: list[str]
+) -> Optional[str]:
     name, amb = resolve_item_prefix(query, ground_names + inv_names)
     if name and not amb:
         return name
@@ -153,4 +158,3 @@ def resolve_key_prefix(query: str) -> Optional[str]:
 
 def display_name(key: str) -> str:
     return REGISTRY[key].name
-

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -80,6 +80,14 @@ class Player:
         """Return inventory item names preserving insertion order."""
         return [items_mod.REGISTRY[k].name for k in self.inventory.keys()]
 
+    def inventory_weight_lbs(self) -> int:
+        total = 0
+        for key, count in self.inventory.items():
+            item = items_mod.REGISTRY.get(key)
+            if item and item.weight_lbs:
+                total += item.weight_lbs * count
+        return total
+
     def pick_up(self, name: str, world) -> None:
         """Pick up an item by name from the ground at the current tile."""
         item = items_mod.find_by_name(name)
@@ -101,4 +109,3 @@ class Player:
         if self.inventory[item.key] == 0:
             del self.inventory[item.key]
         return True, None
-

--- a/tests/test_item_schema.py
+++ b/tests/test_item_schema.py
@@ -1,0 +1,36 @@
+import pytest
+
+from mutants2.engine import items
+from mutants2.engine.player import Player
+
+# mapping of item names to (weight_lbs, ion_value)
+CAPTURE_SET = {
+    "Bottle-Cap": (1, 22000),
+    "Cheese": (1, 12000),
+    "Cigarette-Butt": (1, 11000),
+    "Ion-Booster": (10, 13000),
+    "Ion-Decay": (10, 18000),
+    "Ion-Pack": (50, 20000),
+    "Gold-Chunk": (25, 25000),
+    "Light-Spear": (10, 11000),
+    "Nuclear-Decay": (50, 85000),
+    "Nuclear-Rock": (10, 15000),
+    "Nuclear-thong": (20, 13000),
+    "Nuclear-Waste": (30, 15000),
+}
+
+
+@pytest.mark.parametrize("name,expected", CAPTURE_SET.items())
+def test_catalog_has_correct_values(name, expected):
+    item = items.find_by_name(name)
+    assert item is not None
+    weight, ion = expected
+    assert item.weight_lbs == weight
+    assert item.ion_value == ion
+
+
+def test_inventory_weight_totals():
+    p = Player()
+    p.inventory.update({"ion_decay": 2, "gold_chunk": 1})
+    # weights: ion_decay=10*2=20, gold_chunk=25 -> total 45
+    assert p.inventory_weight_lbs() == 45


### PR DESCRIPTION
## Summary
- extend item schema with `weight_lbs` and `ion_value`
- populate catalog for capture-set items and add inventory weight helper
- add regression tests covering item weights and ion totals

## Testing
- `ruff check mutants2/engine/items.py mutants2/engine/player.py tests/test_item_schema.py --fix`
- `black mutants2/engine/items.py mutants2/engine/player.py tests/test_item_schema.py`
- `pytest`
- pre-commit *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*


------
https://chatgpt.com/codex/tasks/task_e_68b8b5604ed0832b85d4a446ac38abc8