### PR TITLE
Track ions and display inventory weight

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -13,7 +13,7 @@ from ..engine.macros import MacroStore
 from ..engine.types import Direction
 from ..ui.help import MACROS_HELP, ABBREVIATIONS_NOTE, COMMANDS_HELP
 from ..ui.strings import GET_WHAT, DROP_WHAT
-from ..ui.theme import red, SEP
+from ..ui.theme import red, SEP, yellow, cyan
 from ..ui.render import render_help_hint
 from .input import gerundize
 
@@ -317,6 +317,7 @@ def make_context(p, w, save, *, dev: bool = False):
         print(
             f"Class: {p.clazz} | HP: {p.hp}/{p.max_hp} | Year: {p.year} @ {p.x}E : {p.y}N"
         )
+        print(f"Total Ions: {p.ions}")
 
     def handle_command(cmd: str, args: list[str]) -> bool:
         nonlocal last_move
@@ -344,9 +345,15 @@ def make_context(p, w, save, *, dev: bool = False):
                 for line in yells:
                     print(line)
         elif cmd == "inventory":
+            total = p.inventory_weight_lbs()
+            print(
+                yellow(
+                    f"You are carrying the following items: (Total Weight: {total} LB's)"
+                )
+            )
             if p.inventory:
                 for key, count in p.inventory.items():
-                    print(f"{items.REGISTRY[key].name} x{count}")
+                    print(cyan(f"{items.REGISTRY[key].name} x{count}"))
             else:
                 print("(empty)")
         elif cmd == "get":

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -53,6 +53,7 @@ def load() -> tuple[
         player.inventory.update(
             {k: int(v) for k, v in data.get("inventory", {}).items()}
         )
+        player.ions = int(data.get("ions", 0))
         ground: dict[TileKey, ItemListMut] = {}
         for key, val in data.get("ground", {}).items():
             parts = [int(n) for n in key.split(",")]
@@ -123,6 +124,7 @@ def save(player: Player, world: World, save_meta: Save) -> None:
             "hp": player.hp,
             "max_hp": player.max_hp,
             "inventory": {k: v for k, v in player.inventory.items()},
+            "ions": player.ions,
             "ground": {
                 f"{y},{x},{yy}": (items[0] if len(items) == 1 else items)
                 for (y, x, yy), items in world.ground.items()

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -29,6 +29,7 @@ class Player:
     inventory: Dict[str, int] = field(default_factory=dict)
     hp: int = 10
     max_hp: int = 10
+    ions: int = 0
     _last_move_struck_back: bool = field(default=False, repr=False)
 
     @property

--- a/tests/test_player_ions_inventory_weight.py
+++ b/tests/test_player_ions_inventory_weight.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+
+from mutants2.engine import persistence
+from mutants2.engine.player import Player
+from mutants2.engine.world import World
+from mutants2.ui.theme import yellow, cyan
+
+
+def test_inventory_weight_and_stats(cli_runner, tmp_path):
+    persistence.SAVE_PATH = Path(tmp_path) / '.mutants2' / 'save.json'
+    os.environ['HOME'] = str(tmp_path)
+
+    p = Player()
+    p.inventory.update({'ion_decay': 2, 'gold_chunk': 1})
+    w = World(seeded_years={2000})
+    save = persistence.Save()
+    persistence.save(p, w, save)
+
+    out = cli_runner.run_commands(['inventory', 'status'])
+
+    # Inventory header and weight
+    assert yellow("You are carrying the following items: (Total Weight: 45 LB's)") in out
+    assert cyan('Ion-Decay x2') in out and cyan('Gold-Chunk x1') in out
+
+    # Stats page ions
+    assert 'Total Ions: 0' in out
+


### PR DESCRIPTION
## Summary
- Add `ions` attribute to player and persist it in save data
- Show inventory header with total carried weight in yellow and list items in cyan
- Display total ions on the status screen and test inventory weight/ions output

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8b6b3ad68832b9fa136b192a52dcc