### PR TITLE
Add item conversion command

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -28,6 +28,7 @@ NONDIR_CMDS = {
     "drop": "drop",
     "get": "get",
     "take": "get",
+    "convert": "convert",
     "macro": "macro",
     "help": "help",
     "do": "do",
@@ -45,6 +46,7 @@ TURN_CMDS = {
     "travel",
     "get",
     "drop",
+    "convert",
     "attack",
     "rest",
     "look",
@@ -237,6 +239,26 @@ def make_context(p, w, save, *, dev: bool = False):
         print(f"You drop {name}." if ok else (msg or "You can’t drop that here."))
         return False
 
+    def handle_convert(args: list[str]) -> bool:
+        if not args:
+            render_help_hint()
+            return False
+        inv_names = p.inventory_names_in_order()
+        name = items.first_prefix_match(" ".join(args), inv_names)
+        if not name:
+            render_help_hint()
+            return False
+        item = p.convert_item(name)
+        if not item:
+            render_help_hint()
+            return False
+        print(SEP)
+        print(f"The {item.name} vanishes with a flash!")
+        print(f"You convert the {item.name} into {item.ion_value:,} ions.")
+        context._needs_render = False
+        context._suppress_room_render = True
+        return True
+
     def handle_look(args: list[str]) -> bool:
         if not args:
             yells = w.on_entry_aggro_check(
@@ -362,6 +384,9 @@ def make_context(p, w, save, *, dev: bool = False):
         elif cmd == "drop":
             handle_drop(args)
             turn = True
+        elif cmd == "convert":
+            if handle_convert(args):
+                turn = True
         elif cmd == "attack":
             handle_attack()
             turn = True

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -110,3 +110,22 @@ class Player:
         if self.inventory[item.key] == 0:
             del self.inventory[item.key]
         return True, None
+
+    def convert_item(self, name: str) -> items_mod.ItemDef | None:
+        """Convert an inventory item to ions.
+
+        Returns the :class:`ItemDef` of the item converted, or ``None`` if the
+        item was not present or could not be converted.
+        """
+        item = items_mod.find_by_name(name)
+        if not item:
+            return None
+        if self.inventory.get(item.key, 0) <= 0:
+            return None
+        if item.ion_value is None:
+            return None
+        self.inventory[item.key] -= 1
+        if self.inventory[item.key] == 0:
+            del self.inventory[item.key]
+        self.ions += item.ion_value
+        return item

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -49,7 +49,7 @@ Examples
   do 7e3n; look
 """
 
-COMMANDS_HELP = """Commands: look, north, south, east, west, last, travel, class (or x), inventory, get, drop, exit, macro, @name, do
+COMMANDS_HELP = """Commands: look, north, south, east, west, last, travel, class (or x), inventory, get, drop, convert, exit, macro, @name, do
 
 Look
 ----

--- a/tests/test_convert_command.py
+++ b/tests/test_convert_command.py
@@ -1,0 +1,30 @@
+import datetime
+import os
+
+import pytest
+
+from mutants2.engine import persistence
+from mutants2.engine.player import Player
+from mutants2.engine.world import World
+
+
+@pytest.fixture
+def inventory_with_cap(tmp_path):
+    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
+    os.environ['HOME'] = str(tmp_path)
+    p = Player()
+    p.inventory['bottle_cap'] = 1
+    w = World(seeded_years={2000})
+    save = persistence.Save()
+    save.last_topup_date = datetime.date.today().isoformat()
+    persistence.save(p, w, save)
+    return None
+
+
+def test_convert_bottle_cap(cli_runner, inventory_with_cap):
+    out = cli_runner.run_commands(["convert b", "inventory", "status"])
+    assert out.count("***") == 2
+    assert "The Bottle-Cap vanishes with a flash!" in out
+    assert "You convert the Bottle-Cap into 22,000 ions." in out
+    assert "(empty)" in out
+    assert "Total Ions: 22000" in out


### PR DESCRIPTION
## Summary
- allow converting inventory items into ions without re-rendering the room
- document new convert command
- test converting a Bottle-Cap into ions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8b9d328a4832bbe77315cd65c1915