### PR TITLE
Render inventory on one line and colorize convert feedback

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -253,8 +253,8 @@ def make_context(p, w, save, *, dev: bool = False):
             render_help_hint()
             return False
         print(SEP)
-        print(f"The {item.name} vanishes with a flash!")
-        print(f"You convert the {item.name} into {item.ion_value:,} ions.")
+        print(yellow(f"The {item.name} vanishes with a flash!"))
+        print(yellow(f"You convert the {item.name} into {item.ion_value:,} ions."))
         context._needs_render = False
         context._suppress_room_render = True
         return True
@@ -374,8 +374,11 @@ def make_context(p, w, save, *, dev: bool = False):
                 )
             )
             if p.inventory:
+                names: list[str] = []
                 for key, count in p.inventory.items():
-                    print(cyan(f"{items.REGISTRY[key].name} x{count}"))
+                    names.extend([items.REGISTRY[key].name] * count)
+                line = ", ".join(names) + "."
+                print(cyan(line))
             else:
                 print("(empty)")
         elif cmd == "get":

--- a/tests/test_convert_command.py
+++ b/tests/test_convert_command.py
@@ -6,6 +6,7 @@ import pytest
 from mutants2.engine import persistence
 from mutants2.engine.player import Player
 from mutants2.engine.world import World
+from mutants2.ui.theme import yellow
 
 
 @pytest.fixture
@@ -24,7 +25,7 @@ def inventory_with_cap(tmp_path):
 def test_convert_bottle_cap(cli_runner, inventory_with_cap):
     out = cli_runner.run_commands(["convert b", "inventory", "status"])
     assert out.count("***") == 2
-    assert "The Bottle-Cap vanishes with a flash!" in out
-    assert "You convert the Bottle-Cap into 22,000 ions." in out
+    assert yellow("The Bottle-Cap vanishes with a flash!") in out
+    assert yellow("You convert the Bottle-Cap into 22,000 ions.") in out
     assert "(empty)" in out
     assert "Total Ions: 22000" in out

--- a/tests/test_items_basic.py
+++ b/tests/test_items_basic.py
@@ -6,6 +6,7 @@ import sys
 from mutants2.engine import persistence
 from mutants2.engine.world import World
 from mutants2.engine.player import Player
+from mutants2.ui.theme import cyan
 
 
 def _run_game(commands, tmp_path):
@@ -36,7 +37,7 @@ def test_pickup_and_drop_roundtrip(tmp_path):
     result = _run_game(['get Ion-Decay', 'look', 'inventory', 'drop Ion-Decay', 'look', 'inventory', 'exit'], tmp_path)
     out = result.stdout
     assert 'You pick up Ion-Decay.' in out
-    assert 'Ion-Decay x1' in out
+    assert cyan('Ion-Decay.') in out
     assert 'You drop Ion-Decay.' in out
     after = out.split('You drop Ion-Decay.')[-1]
     assert 'On the ground lies:' in after and 'Ion-Decay' in after
@@ -52,8 +53,7 @@ def test_inventory_rendering(tmp_path):
     save = persistence.Save()
     persistence.save(p, w, save)
     result = _run_game(['inventory', 'exit'], tmp_path)
-    assert 'Ion-Decay x2' in result.stdout
-    assert 'Gold-Chunk x1' in result.stdout
+    assert cyan('Ion-Decay, Ion-Decay, Gold-Chunk.') in result.stdout
 
 
 def test_persistence_inventory_and_ground(tmp_path):
@@ -66,7 +66,7 @@ def test_persistence_inventory_and_ground(tmp_path):
     _run_game(['get Ion-Decay', 'east', 'exit'], tmp_path)
     result = _run_game(['inventory', 'west', 'look', 'exit'], tmp_path)
     out = result.stdout
-    assert 'Ion-Decay x1' in out
+    assert cyan('Ion-Decay.') in out
     assert 'On the ground lies:' not in out
 
 
@@ -78,4 +78,4 @@ def test_name_matching_case_insensitive(tmp_path):
     save = persistence.Save()
     persistence.save(p, w, save)
     result = _run_game(['get ion-decay', 'drop ion-decay', 'get Ion-Decay', 'inventory', 'exit'], tmp_path)
-    assert 'Ion-Decay x1' in result.stdout
+    assert cyan('Ion-Decay.') in result.stdout

--- a/tests/test_player_ions_inventory_weight.py
+++ b/tests/test_player_ions_inventory_weight.py
@@ -21,7 +21,7 @@ def test_inventory_weight_and_stats(cli_runner, tmp_path):
 
     # Inventory header and weight
     assert yellow("You are carrying the following items: (Total Weight: 45 LB's)") in out
-    assert cyan('Ion-Decay x2') in out and cyan('Gold-Chunk x1') in out
+    assert cyan('Ion-Decay, Ion-Decay, Gold-Chunk.') in out
 
     # Stats page ions
     assert 'Total Ions: 0' in out


### PR DESCRIPTION
## Summary
- render inventory items on a single cyan line without counts
- colorize convert success messages in yellow
- adjust tests for new inventory format and convert styling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b8c1b90ebc832bb42c6c092a0171fa