### PR TITLE
Implement per-class isolation and robust macro/profile management

### DIFF
--- a/mutants2/engine/macros.py
+++ b/mutants2/engine/macros.py
@@ -46,12 +46,20 @@ class MacroStore:
             json.dump(data, f)
 
     def load_profile(self, profile: str) -> None:
+        self.MACRO_DIR.mkdir(parents=True, exist_ok=True)
         path = self.MACRO_DIR / f"{profile}.json"
-        with path.open("r", encoding="utf-8") as f:
-            data = json.load(f)
+        try:
+            with path.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+        except FileNotFoundError:
+            data = {"macros": {}, "echo": True}
+            with path.open("w", encoding="utf-8") as f:
+                json.dump(data, f)
+        except Exception:
+            data = {"macros": {}, "echo": True}
         self._macros.update(data.get("macros", {}))
         if "echo" in data:
-            self.echo = data["echo"]
+            self.echo = bool(data["echo"])
 
     def list_profiles(self) -> List[str]:
         if not self.MACRO_DIR.is_dir():

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -10,11 +10,18 @@ from .world import ALLOWED_CENTURIES
 from ..ui.theme import red
 
 
+def class_key(name: str) -> str:
+    """Return the canonical key for ``name``."""
+
+    return name.strip().lower()
+
+
 # Available player classes. These are simple placeholders for now and do not
 # affect gameplay beyond being tracked and persisted.
 CLASS_LIST = ["Warrior", "Mage", "Wizard", "Thief", "Priest"]
-CLASS_BY_NUM = {str(i + 1): c for i, c in enumerate(CLASS_LIST)}
-CLASS_BY_NAME = {c.lower(): c for c in CLASS_LIST}
+CLASS_DISPLAY = {class_key(c): c for c in CLASS_LIST}
+CLASS_BY_NUM = {str(i + 1): class_key(c) for i, c in enumerate(CLASS_LIST)}
+CLASS_BY_NAME = {class_key(c): class_key(c) for c in CLASS_LIST}
 
 
 @dataclass

--- a/mutants2/engine/state.py
+++ b/mutants2/engine/state.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Tuple
+from typing import Dict, Tuple, TYPE_CHECKING
 
 from .world import ALLOWED_CENTURIES
+
+if TYPE_CHECKING:  # pragma: no cover - import cycle guard
+    from .player import Player
 
 
 @dataclass
@@ -16,3 +19,55 @@ class CharacterProfile:
     hp: int = 10
     max_hp: int = 10
     ions: int = 0
+    macros_name: str | None = None
+
+
+def profile_from_player(p: "Player") -> CharacterProfile:
+    """Extract a :class:`CharacterProfile` from ``p``."""
+
+    return CharacterProfile(
+        year=p.year,
+        positions=dict(p.positions),
+        inventory=dict(p.inventory),
+        hp=p.hp,
+        max_hp=p.max_hp,
+        ions=p.ions,
+    )
+
+
+def apply_profile(p: "Player", prof: CharacterProfile) -> None:
+    """Apply ``prof`` to ``p`` in-place."""
+
+    p.year = prof.year
+    p.positions = {int(y): (x, y2) for y, (x, y2) in prof.positions.items()}
+    p.inventory = dict(prof.inventory)
+    p.hp = prof.hp
+    p.max_hp = prof.max_hp
+    p.ions = prof.ions
+
+
+def profile_to_raw(prof: CharacterProfile) -> dict:
+    return {
+        "year": prof.year,
+        "positions": {str(y): {"x": x, "y": yy} for y, (x, yy) in prof.positions.items()},
+        "inventory": {k: v for k, v in prof.inventory.items()},
+        "hp": prof.hp,
+        "max_hp": prof.max_hp,
+        "ions": prof.ions,
+        **({"macros_name": prof.macros_name} if prof.macros_name else {}),
+    }
+
+
+def profile_from_raw(data: dict) -> CharacterProfile:
+    return CharacterProfile(
+        year=int(data.get("year", ALLOWED_CENTURIES[0])),
+        positions={
+            int(k): (v.get("x", 0), v.get("y", 0))
+            for k, v in data.get("positions", {}).items()
+        },
+        inventory={k: int(v) for k, v in data.get("inventory", {}).items()},
+        hp=int(data.get("hp", 10)),
+        max_hp=int(data.get("max_hp", 10)),
+        ions=int(data.get("ions", 0)),
+        macros_name=data.get("macros_name"),
+    )


### PR DESCRIPTION
## Summary
- introduce `class_key` helper and canonicalize class identifiers
- persist character data per class and migrate old saves/macros
- auto-create per-class macro files and load them safely

## Testing
- `pytest`
- `pre-commit run --files mutants2/engine/player.py mutants2/engine/state.py mutants2/engine/persistence.py mutants2/engine/macros.py mutants2/cli/shell.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*


------
https://chatgpt.com/codex/tasks/task_e_68b9a05f0a44832ba5363276c9bb4ab5