### PR TITLE
Centralize aggro handling and travel turn logic

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -234,21 +234,6 @@ def make_context(p, w, save, *, dev: bool = False):
         else:
             print("Invalid macro command.")
 
-    def _ordinal_century(year: int) -> str:
-        n = year // 100 + 1
-        if n % 100 not in {11, 12, 13}:
-            if n % 10 == 1:
-                suff = "st"
-            elif n % 10 == 2:
-                suff = "nd"
-            elif n % 10 == 3:
-                suff = "rd"
-            else:
-                suff = "th"
-        else:
-            suff = "th"
-        return f"{n}{suff}"
-
     def handle_travel(args: list[str]) -> bool:
         if not args:
             render_usage("travel")
@@ -266,18 +251,11 @@ def make_context(p, w, save, *, dev: bool = False):
             context._suppress_room_render = True
             return False
         target = max(c for c in ALLOWED_CENTURIES if c <= year_input)
-        if target == p.year:
-            print(white(f"You're already in the {_ordinal_century(target)} Century!"))
-            context._suppress_room_render = True
-            context._needs_render = False
-            context._suppress_entry_aggro = True
-            context._skip_movement_tick = True
-            return True
         p.travel(w, target)
         print(white(f"ZAAAAPPPPP!! You've been sent to the year {target} A.D."))
         context._suppress_room_render = True
         context._suppress_entry_aggro = True
-        context._skip_movement_tick = True
+        context._skip_movement_tick = False
         context._needs_render = False
         return True
 

--- a/mutants2/engine/ai.py
+++ b/mutants2/engine/ai.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from typing import MutableMapping, Optional
+
+from ..ui.render import print_yell
+
+
+def set_aggro(mon: MutableMapping[str, object]) -> Optional[str]:
+    """Flip a monster to aggro and emit its yell once.
+
+    Returns the yell line when it was printed, otherwise ``None``.
+    """
+    if not mon.get("aggro", False):
+        mon["aggro"] = True
+        mon["seen"] = True
+        if not mon.get("yelled_once", False):
+            mon["yelled_once"] = True
+            return print_yell(mon)
+    return None

--- a/mutants2/engine/monsters.py
+++ b/mutants2/engine/monsters.py
@@ -58,6 +58,7 @@ def spawn(key: str, mid: int) -> dict:
         "name": name,
         "aggro": False,
         "seen": False,
+        "yelled_once": False,
         "id": mid,
         "hp": REGISTRY[key].base_hp,
     }

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -128,6 +128,7 @@ def load() -> tuple[
                 name = entry.get("name")
                 aggro = entry.get("aggro", False)
                 seen = entry.get("seen", False)
+                yelled_once = entry.get("yelled_once", False)
                 mid = entry.get("id")
                 base = monsters_mod.REGISTRY[m_key].base_hp
                 m: dict[str, object] = {
@@ -136,6 +137,7 @@ def load() -> tuple[
                     "name": name or monsters_mod.REGISTRY[m_key].name,
                     "aggro": bool(aggro),
                     "seen": bool(seen),
+                    "yelled_once": bool(yelled_once),
                 }
                 if mid is not None:
                     m["id"] = int(mid)
@@ -205,16 +207,17 @@ def save(player: Player, world: World, save_meta: Save) -> None:
                 for (y, x, yy), lst in world.monsters.items()
                 for processed in [
                     [
-                        {
-                            "key": m["key"],
-                            "hp": m["hp"],
-                            "name": m.get("name"),
-                            "aggro": m.get("aggro", False),
-                            "seen": m.get("seen", False),
-                            "id": m.get("id"),
-                        }
-                        for m in lst
-                    ]
+                            {
+                                "key": m["key"],
+                                "hp": m["hp"],
+                                "name": m.get("name"),
+                                "aggro": m.get("aggro", False),
+                                "seen": m.get("seen", False),
+                                "yelled_once": m.get("yelled_once", False),
+                                "id": m.get("id"),
+                            }
+                            for m in lst
+                        ]
                 ]
             },
             "seeded_years": list(world.seeded_years),

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -23,6 +23,7 @@ from .types import (
     TileKey,
 )
 from . import monsters as monsters_mod, items as items_mod, rng as rng_mod
+from .ai import set_aggro
 from ..data.room_headers import ROOM_HEADERS
 
 Coordinate = Tuple[int, int]
@@ -134,6 +135,7 @@ class World:
                     hp_int = int(cast(int, hp_val)) if hp_val is not None else None
                     aggro = entry.get("aggro", False)
                     seen = entry.get("seen", False)
+                    yelled_once = entry.get("yelled_once", False)
                     mid_val = entry.get("id")
                     mid = int(cast(int, mid_val)) if mid_val is not None else None
                     base = monsters_mod.REGISTRY[m_key].base_hp
@@ -148,6 +150,7 @@ class World:
                         "name": name,
                         "aggro": bool(aggro),
                         "seen": bool(seen),
+                        "yelled_once": bool(yelled_once),
                         "id": int(mid),
                     }
                     if m.get("aggro") and not m.get("seen"):
@@ -283,8 +286,9 @@ class World:
             if mm.get("aggro"):
                 continue
             if hrand(base.random(), mm.get("id"), "mroll").random() < 0.5:
-                mm["aggro"] = True
-                yells.append(f"{mm['name']} yells at you!")
+                msg = set_aggro(mm)
+                if msg:
+                    yells.append(msg)
         return yells
 
     def reset_all_aggro(self) -> None:

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -5,3 +5,9 @@ def render_help_hint() -> None:
     """Print the standard help hint in yellow."""
     print(SEP)
     print(yellow("Type ? if you need assistance."))
+
+
+def print_yell(mon) -> str:
+    """Return the yell line for a monster."""
+    name = mon.get("name") or mon.get("key")
+    return f"{name} yells at you!"

--- a/tests/smoke/test_travel_yell_and_arrivals.py
+++ b/tests/smoke/test_travel_yell_and_arrivals.py
@@ -1,0 +1,71 @@
+import contextlib
+from io import StringIO
+
+import pytest
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+from mutants2.engine.ai import set_aggro
+
+
+def run_cli(world, commands, tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    save = persistence.Save()
+    p = Player()
+    p.clazz = "Warrior"
+    ctx = make_context(p, world, save)
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        for cmd in commands:
+            ctx.dispatch_line(cmd)
+    return buf.getvalue()
+
+
+def test_yell_once_on_aggro(tmp_path, monkeypatch):
+    w = world_mod.World()
+    w.year(2000)
+    for (x, y), _ in list(w.monsters_in_year(2000).items()):
+        w.remove_monster(2000, x, y)
+    w.place_monster(2000, 0, 0, "mutant")
+
+    def always(year, x, y, player, seed_parts=()):
+        yells = []
+        for m in w.monsters_here(year, x, y):
+            msg = set_aggro(m)
+            if msg:
+                yells.append(msg)
+        return yells
+
+    monkeypatch.setattr(w, "on_entry_aggro_check", always)
+    out = run_cli(w, ["look", "look"], tmp_path, monkeypatch)
+    assert out.count("yells at you!") == 1
+
+
+def test_same_century_travel_teleports(tmp_path, monkeypatch):
+    w = world_mod.World()
+    for yr in (2000, 2100):
+        w.year(yr)
+        for (x, y), _ in list(w.monsters_in_year(yr).items()):
+            w.remove_monster(yr, x, y)
+    out = run_cli(w, ["travel 2100", "east", "travel 2100", "look"], tmp_path, monkeypatch)
+    lines = out.splitlines()
+    idxs = [i for i, ln in enumerate(lines) if ln == "travel 2100"]
+    second = idxs[1]
+    assert "ZAAAAPPPPP!! You've been sent to the year 2100 A.D." in lines[second + 1]
+    look_idx = lines.index("look", second + 1)
+    assert not any("Compass" in ln for ln in lines[second + 1:look_idx])
+    assert any("Compass: (0E : 0N)" in ln for ln in lines[look_idx + 1:])
+
+
+def test_travel_triggers_arrival(tmp_path, monkeypatch):
+    w = world_mod.World()
+    w.year(2000)
+    for (x, y), _ in list(w.monsters_in_year(2000).items()):
+        w.remove_monster(2000, x, y)
+    w.place_monster(2000, 1, 0, "mutant")
+    w.monster_here(2000, 1, 0)["aggro"] = True
+    out = run_cli(w, ["travel 2000"], tmp_path, monkeypatch)
+    assert "ZAAAAPPPPP!! You've been sent to the year 2000 A.D." in out
+    assert "has just arrived from the east" in out
+    assert "Compass" not in out

--- a/tests/test_no_preaggro_after_travel.py
+++ b/tests/test_no_preaggro_after_travel.py
@@ -1,6 +1,5 @@
 import contextlib
 from io import StringIO
-import contextlib
 
 import pytest
 
@@ -66,11 +65,10 @@ def test_no_preaggro_after_travel(cli):
     assert "has just arrived" not in text2
 
 
-def test_travel_same_century_message(cli):
+def test_travel_same_century_ticks(cli):
     out = cli.run(["travel 2000"])
     lines = [ln for ln in out.strip().splitlines()]
-    assert len(lines) == 2
-    assert "You're already in the 21st Century!" in lines[1]
-    text = out.lower()
-    assert "footsteps" not in text
-    assert "has just arrived" not in text
+    assert len(lines) == 3
+    assert "ZAAAAPPPPP!! You've been sent to the year 2000 A.D." in lines[1]
+    assert "footsteps" in lines[2]
+    assert "Compass" not in out


### PR DESCRIPTION
## Summary
- Add `set_aggro` helper to flip monsters to aggro and emit a one-time yell
- Treat all travel commands as teleportations to (0E:0N) that consume a turn and trigger follower movement
- Cover yell, teleport, and arrival behaviours with new smoke tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ce1065fc832ba7a3b44e06754fc4