### PR TITLE
Restrict look to inventory and overhaul stats display

### DIFF
--- a/mutants2/render.py
+++ b/mutants2/render.py
@@ -45,7 +45,8 @@ def render_room_at(
     # (c) exits
     for d in ("north", "south", "east", "west"):
         if world.is_open(year, x, y, d):
-            out.append(cyan(f"{d} – area continues."))
+            # Pad direction labels to align the separator across lines.
+            out.append(cyan(f"{d:<5} – area continues."))
 
     # (d/e) ground items followed by a single separator
     ground_names = [it.name for it in world.items_on_ground(year, x, y)]

--- a/tests/smoke/test_footsteps_and_spawnable_look.py
+++ b/tests/smoke/test_footsteps_and_spawnable_look.py
@@ -57,4 +57,4 @@ def test_spawnable_look_lovely(tmp_path):
     with contextlib.redirect_stdout(buf):
         ctx.dispatch_line("look nuclear")
     out = buf.getvalue()
-    assert yellow("It looks like a lovely Nuclear-Rock!") in out
+    assert yellow("You're not carrying a nuclear.") in out

--- a/tests/smoke/test_stats_page.py
+++ b/tests/smoke/test_stats_page.py
@@ -1,0 +1,28 @@
+import contextlib
+import datetime
+import io
+
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+from mutants2.cli.shell import make_context
+from mutants2.ui.theme import yellow, cyan
+
+
+def test_stats_page(tmp_path):
+    persistence.SAVE_PATH = tmp_path / 'save.json'
+    p = Player(year=2000, clazz='Warrior')
+    p.inventory.update({'ion_decay': 2, 'gold_chunk': 1})
+    w = world_mod.World(seeded_years={2000})
+    save = persistence.Save()
+    save.last_topup_date = datetime.date.today().isoformat()
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('status')
+    out = buf.getvalue()
+    assert yellow('Name: Vindeiatrix / Mutant Warrior') in out
+    assert yellow('Hit Points   : 10 / 10') in out
+    assert yellow('Ions         : 0') in out
+    assert yellow('Year A.D.     : 2000') in out
+    assert yellow("You are carrying the following items:  (Total Weight: 45 LB's)") in out
+    assert cyan('Ion-Decay, Ion-Decay, Gold-Chunk.') in out

--- a/tests/smoke/test_travel_convert_and_items.py
+++ b/tests/smoke/test_travel_convert_and_items.py
@@ -27,7 +27,7 @@ def test_monster_bait_conversion(cli_runner, tmp_path):
     assert yellow('The Monster-Bait vanishes with a flash!') in out
     assert yellow('You convert the Monster-Bait into 10,000 ions.') in out
     assert '(empty)' in out
-    assert 'Total Ions: 10000' in out
+    assert 'Ions         : 10000' in out
 
 
 def test_convert_gibberish(cli_runner):
@@ -39,7 +39,7 @@ def test_convert_gibberish(cli_runner):
 def test_travel_rounding_and_stats(cli_runner):
     out = cli_runner.run_commands(['tra 2149', 'status'])
     assert white("ZAAAAPPPPP!! You've been sent to the year 2100 A.D.") in out
-    assert 'Year: 2100' in out
+    assert 'Year A.D.     : 2100' in out
 
 
 def test_travel_out_of_range(cli_runner):

--- a/tests/test_classes.py
+++ b/tests/test_classes.py
@@ -46,7 +46,7 @@ def test_persistence_of_class(tmp_path):
     run_cli('4\nnorth\nexit\n', home)
     result = run_cli('sta\nexit\n', home)
     out = result.stdout
-    assert 'Class: Thief' in out
+    assert 'Mutant Thief' in out
     assert 'Choose your class' not in out
 
 

--- a/tests/test_combat_minimal.py
+++ b/tests/test_combat_minimal.py
@@ -68,7 +68,7 @@ def test_rest_heals_when_safe(empty_start_world, cli_runner):
 
 def test_status_shows_hp_and_coords(empty_start_world, cli_runner):
     out = cli_runner.run_commands(["sta"])
-    assert "HP:" in out and "Year:" in out
+    assert "Hit Points" in out and "Year A.D." in out
 
 
 def test_room_line_shows_monster_present(world_with_mutant_on_start, cli_runner):

--- a/tests/test_convert_command.py
+++ b/tests/test_convert_command.py
@@ -28,4 +28,4 @@ def test_convert_bottle_cap(cli_runner, inventory_with_cap):
     assert yellow("The Bottle-Cap vanishes with a flash!") in out
     assert yellow("You convert the Bottle-Cap into 22,000 ions.") in out
     assert "(empty)" in out
-    assert "Total Ions: 22000" in out
+    assert "Ions         : 22000" in out

--- a/tests/test_look_lovely_ground_item.py
+++ b/tests/test_look_lovely_ground_item.py
@@ -8,7 +8,7 @@ from mutants2.cli.shell import make_context
 from mutants2.ui.theme import yellow
 
 
-def test_look_ground_item_lovely(tmp_path):
+def test_look_ground_item_not_carried(tmp_path):
     persistence.SAVE_PATH = tmp_path / 'save.json'
     w = world_mod.World({(2000, 0, 0): ['nuclear_rock']}, {2000})
     p = Player(year=2000, clazz='Warrior')
@@ -19,4 +19,4 @@ def test_look_ground_item_lovely(tmp_path):
     with contextlib.redirect_stdout(buf):
         ctx.dispatch_line('look nuclear')
     out = buf.getvalue()
-    assert yellow('It looks like a lovely Nuclear-Rock!') in out
+    assert yellow("You're not carrying a nuclear.") in out

--- a/tests/test_player_ions_inventory_weight.py
+++ b/tests/test_player_ions_inventory_weight.py
@@ -24,5 +24,5 @@ def test_inventory_weight_and_stats(cli_runner, tmp_path):
     assert cyan('Ion-Decay, Ion-Decay, Gold-Chunk.') in out
 
     # Stats page ions
-    assert 'Total Ions: 0' in out
+    assert 'Ions         : 0' in out
 

--- a/tests/test_senses_and_look_targets.py
+++ b/tests/test_senses_and_look_targets.py
@@ -50,9 +50,9 @@ def test_look_dir_and_blocked(cli):
 def test_look_item_and_monster(cli, world):
     world.place_item(2000, 0, 0, "gold_chunk")
     out = cli.run(["look gold"])
-    assert "gold-chunk" in out.lower()
+    assert "not carrying a gold" in out.lower()
     world.place_monster(2000, 1, 0, "mutant")
     out = cli.run(["look mut"])
-    assert "can't look that way" in out.lower()
+    assert "not carrying a mut" in out.lower()
 
 


### PR DESCRIPTION
## Summary
- Look command now only recognizes carried items and warns when item not in inventory
- Compass exits now pad direction labels so east/west align with north/south
- Added new detailed Stats page with inventory summary
- Added smoke tests for inventory-only look, exit spacing, and new stats page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9de6703d8832b9573ad93b809a330