### PR TITLE
Implement table-driven class progression

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -26,7 +26,7 @@ from ..engine.world import ALLOWED_CENTURIES
 from ..ui.help import MACROS_HELP, ABBREVIATIONS_NOTE, COMMANDS_HELP, USAGE
 from ..ui.strings import GET_WHAT, DROP_WHAT
 from ..ui.theme import red, SEP, yellow, cyan, white
-from ..ui.render import render_help_hint
+from ..ui.render import render_help_hint, render_status
 from .input import gerundize
 
 
@@ -442,26 +442,7 @@ def make_context(p, w, save, *, dev: bool = False):
             print(yellow("You're healed to the maximum!"))
 
     def handle_status() -> None:
-        disp = CLASS_DISPLAY.get(class_key(p.clazz or ""), p.clazz or "")
-        lines = [
-            yellow(f"Name: Vindeiatrix / Mutant {disp}"),
-            yellow("Exhaustion   : 0"),
-            yellow(
-                f"Str: {p.strength:<2}   Int: {p.intelligence:<2}   Wis: {p.wisdom:<2}"
-            ),
-            yellow(
-                f"Dex: {p.dexterity:<2}   Con: {p.constitution:<2}   Cha: {p.charisma:<2}"
-            ),
-            yellow(f"Hit Points   : {p.hp} / {p.max_hp}"),
-            yellow(f"Exp. Points  : {p.exp}           Level: {p.level}"),
-            yellow("Riblets      : 0"),
-            yellow(f"Ions         : {p.ions}"),
-            yellow(f"Wearing Armor: Nothing.  Armour Class: {p.ac}"),
-            yellow("Ready to Combat: NO ONE"),
-            yellow("Readied Spell : No spell memorized."),
-            yellow(f"Year A.D.     : {p.year}"),
-            "",
-        ]
+        lines = render_status(p)
         total = p.inventory_weight_lbs()
         lines.append(
             yellow(

--- a/mutants2/data/class_tables.py
+++ b/mutants2/data/class_tables.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+# Level 1 base stats for each class
+BASE_LEVEL1 = {
+    "thief": {"str": 15, "int": 9, "wis": 8, "dex": 14, "con": 15, "cha": 16, "hp": 18, "ac": 1},
+    "priest": {"str": 20, "int": 12, "wis": 13, "dex": 17, "con": 17, "cha": 14, "hp": 30, "ac": 1},
+    "wizard": {"str": 14, "int": 17, "wis": 17, "dex": 13, "con": 14, "cha": 15, "hp": 23, "ac": 1},
+    "warrior": {"str": 23, "int": 12, "wis": 14, "dex": 20, "con": 19, "cha": 9, "hp": 40, "ac": 2},
+    "mage": {"str": 18, "int": 23, "wis": 20, "dex": 16, "con": 15, "cha": 20, "hp": 28, "ac": 1},
+}
+
+# Per-level progression tables.
+PROGRESSION = {
+    "thief": {
+        2: {"xp_to_reach": 30_000, "hp_plus": 3, "str_plus": 2, "int_plus": 2, "wis_plus": 2, "dex_plus": 2, "con_plus": 3, "cha_plus": 2},
+        3: {"xp_to_reach": 100_000, "hp_plus": 3, "str_plus": 2, "int_plus": 3, "wis_plus": 2, "dex_plus": 3, "con_plus": 3, "cha_plus": 2},
+        4: {"xp_to_reach": 210_000, "hp_plus": 4, "str_plus": 3, "int_plus": 3, "wis_plus": 2, "dex_plus": 4, "con_plus": 4, "cha_plus": 2},
+        5: {"xp_to_reach": 340_000, "hp_plus": 5, "str_plus": 3, "int_plus": 3, "wis_plus": 2, "dex_plus": 5, "con_plus": 4, "cha_plus": 2},
+        6: {"xp_to_reach": 540_000, "hp_plus": 6, "str_plus": 3, "int_plus": 4, "wis_plus": 2, "dex_plus": 6, "con_plus": 6, "cha_plus": 2},
+        7: {"xp_to_reach": 700_000, "hp_plus": 7, "str_plus": 4, "int_plus": 4, "wis_plus": 3, "dex_plus": 7, "con_plus": 7, "cha_plus": 3},
+        8: {"xp_to_reach": 930_000, "hp_plus": 8, "str_plus": 4, "int_plus": 4, "wis_plus": 3, "dex_plus": 8, "con_plus": 7, "cha_plus": 3},
+        9: {"xp_to_reach": 1_900_000, "hp_plus": 8, "str_plus": 4, "int_plus": 4, "wis_plus": 3, "dex_plus": 9, "con_plus": 8, "cha_plus": 3},
+        10:{"xp_to_reach": 2_400_000, "hp_plus": 8, "str_plus": 5, "int_plus": 4, "wis_plus": 3, "dex_plus": 10, "con_plus": 8, "cha_plus": 3},
+        11:{"xp_to_reach": 3_300_000, "hp_plus": 9, "str_plus": 6, "int_plus": 5, "wis_plus": 4, "dex_plus": 11, "con_plus": 9, "cha_plus": 4},
+    },
+    "priest": {
+        2: {"xp_to_reach": 40_000, "hp_plus": 1, "str_plus": 1, "int_plus": 1, "wis_plus": 1, "dex_plus": 4, "con_plus": 2, "cha_plus": 2},
+        3: {"xp_to_reach": 80_000, "hp_plus": 2, "str_plus": 1, "int_plus": 1, "wis_plus": 1, "dex_plus": 4, "con_plus": 2, "cha_plus": 2},
+        4: {"xp_to_reach": 170_000, "hp_plus": 3, "str_plus": 2, "int_plus": 1, "wis_plus": 3, "dex_plus": 5, "con_plus": 2, "cha_plus": 3},
+        5: {"xp_to_reach": 290_000, "hp_plus": 3, "str_plus": 3, "int_plus": 2, "wis_plus": 3, "dex_plus": 5, "con_plus": 2, "cha_plus": 4},
+        6: {"xp_to_reach": 410_000, "hp_plus": 3, "str_plus": 3, "int_plus": 2, "wis_plus": 4, "dex_plus": 6, "con_plus": 2, "cha_plus": 5},
+        7: {"xp_to_reach": 650_000, "hp_plus": 3, "str_plus": 3, "int_plus": 2, "wis_plus": 4, "dex_plus": 6, "con_plus": 3, "cha_plus": 6},
+        8: {"xp_to_reach": 890_000, "hp_plus": 3, "str_plus": 4, "int_plus": 3, "wis_plus": 5, "dex_plus": 6, "con_plus": 3, "cha_plus": 7},
+        9: {"xp_to_reach": 1_100_000, "hp_plus": 4, "str_plus": 4, "int_plus": 3, "wis_plus": 5, "dex_plus": 7, "con_plus": 3, "cha_plus": 8},
+        10:{"xp_to_reach": 2_300_000, "hp_plus": 4, "str_plus": 5, "int_plus": 3, "wis_plus": 6, "dex_plus": 7, "con_plus": 3, "cha_plus": 8},
+        11:{"xp_to_reach": 5_400_000, "hp_plus": 5, "str_plus": 5, "int_plus": 4, "wis_plus": 6, "dex_plus": 7, "con_plus": 3, "cha_plus": 8},
+    },
+    "wizard": {
+        2: {"xp_to_reach": 40_000, "hp_plus": 1, "str_plus": 1, "int_plus": 3, "wis_plus": 2, "dex_plus": 1, "con_plus": 1, "cha_plus": 5},
+        3: {"xp_to_reach": 90_000, "hp_plus": 2, "str_plus": 1, "int_plus": 3, "wis_plus": 2, "dex_plus": 1, "con_plus": 1, "cha_plus": 6},
+        4: {"xp_to_reach": 190_000, "hp_plus": 2, "str_plus": 1, "int_plus": 4, "wis_plus": 3, "dex_plus": 1, "con_plus": 1, "cha_plus": 7},
+        5: {"xp_to_reach": 310_000, "hp_plus": 2, "str_plus": 2, "int_plus": 5, "wis_plus": 3, "dex_plus": 2, "con_plus": 2, "cha_plus": 8},
+        6: {"xp_to_reach": 560_000, "hp_plus": 3, "str_plus": 2, "int_plus": 6, "wis_plus": 4, "dex_plus": 2, "con_plus": 2, "cha_plus": 9},
+        7: {"xp_to_reach": 780_000, "hp_plus": 3, "str_plus": 2, "int_plus": 6, "wis_plus": 4, "dex_plus": 2, "con_plus": 2, "cha_plus": 9},
+        8: {"xp_to_reach": 1_300_000, "hp_plus": 3, "str_plus": 2, "int_plus": 6, "wis_plus": 5, "dex_plus": 2, "con_plus": 2, "cha_plus": 9},
+        9: {"xp_to_reach": 2_100_000, "hp_plus": 4, "str_plus": 2, "int_plus": 7, "wis_plus": 5, "dex_plus": 2, "con_plus": 3, "cha_plus": 9},
+        10:{"xp_to_reach": 3_350_000, "hp_plus": 4, "str_plus": 2, "int_plus": 7, "wis_plus": 6, "dex_plus": 3, "con_plus": 3, "cha_plus": 10},
+        11:{"xp_to_reach": 4_800_000, "hp_plus": 4, "str_plus": 2, "int_plus": 7, "wis_plus": 7, "dex_plus": 3, "con_plus": 3, "cha_plus": 11},
+    },
+    "warrior": {
+        2: {"xp_to_reach": 50_000, "hp_plus": 4, "str_plus": 8, "int_plus": 1, "wis_plus": 1, "dex_plus": 3, "con_plus": 3, "cha_plus": 1},
+        3: {"xp_to_reach": 130_000, "hp_plus": 5, "str_plus": 8, "int_plus": 1, "wis_plus": 1, "dex_plus": 5, "con_plus": 4, "cha_plus": 1},
+        4: {"xp_to_reach": 320_000, "hp_plus": 5, "str_plus": 9, "int_plus": 1, "wis_plus": 1, "dex_plus": 7, "con_plus": 6, "cha_plus": 1},
+        5: {"xp_to_reach": 510_000, "hp_plus": 6, "str_plus": 10, "int_plus": 1, "wis_plus": 1, "dex_plus": 8, "con_plus": 8, "cha_plus": 1},
+        6: {"xp_to_reach": 860_000, "hp_plus": 7, "str_plus": 12, "int_plus": 1, "wis_plus": 1, "dex_plus": 10, "con_plus": 11, "cha_plus": 1},
+        7: {"xp_to_reach": 1_150_000, "hp_plus": 8, "str_plus": 15, "int_plus": 1, "wis_plus": 1, "dex_plus": 12, "con_plus": 13, "cha_plus": 1},
+        8: {"xp_to_reach": 2_100_000, "hp_plus": 8, "str_plus": 18, "int_plus": 1, "wis_plus": 1, "dex_plus": 12, "con_plus": 15, "cha_plus": 1},
+        9: {"xp_to_reach": 3_250_000, "hp_plus": 10, "str_plus": 20, "int_plus": 1, "wis_plus": 1, "dex_plus": 15, "con_plus": 18, "cha_plus": 1},
+        10:{"xp_to_reach": 4_990_000, "hp_plus": 10, "str_plus": 22, "int_plus": 1, "wis_plus": 1, "dex_plus": 18, "con_plus": 20, "cha_plus": 1},
+        11:{"xp_to_reach": 5_400_000, "hp_plus": 11, "str_plus": 25, "int_plus": 1, "wis_plus": 1, "dex_plus": 20, "con_plus": 20, "cha_plus": 1},
+    },
+    "mage": {
+        2: {"xp_to_reach": 40_000, "hp_plus": 2, "str_plus": 3, "int_plus": 6, "wis_plus": 5, "dex_plus": 1, "con_plus": 2, "cha_plus": 3},
+        3: {"xp_to_reach": 90_000, "hp_plus": 3, "str_plus": 3, "int_plus": 6, "wis_plus": 6, "dex_plus": 2, "con_plus": 3, "cha_plus": 3},
+        4: {"xp_to_reach": 400_000, "hp_plus": 4, "str_plus": 3, "int_plus": 7, "wis_plus": 6, "dex_plus": 3, "con_plus": 4, "cha_plus": 4},
+        5: {"xp_to_reach": 1_120_000, "hp_plus": 5, "str_plus": 4, "int_plus": 7, "wis_plus": 7, "dex_plus": 3, "con_plus": 4, "cha_plus": 4},
+        6: {"xp_to_reach": 1_650_000, "hp_plus": 6, "str_plus": 4, "int_plus": 8, "wis_plus": 7, "dex_plus": 3, "con_plus": 4, "cha_plus": 5},
+        7: {"xp_to_reach": 2_400_000, "hp_plus": 6, "str_plus": 4, "int_plus": 8, "wis_plus": 8, "dex_plus": 4, "con_plus": 5, "cha_plus": 5},
+        8: {"xp_to_reach": 3_250_000, "hp_plus": 6, "str_plus": 4, "int_plus": 8, "wis_plus": 8, "dex_plus": 5, "con_plus": 5, "cha_plus": 5},
+        9: {"xp_to_reach": 4_000_000, "hp_plus": 6, "str_plus": 4, "int_plus": 9, "wis_plus": 9, "dex_plus": 5, "con_plus": 5, "cha_plus": 5},
+        10:{"xp_to_reach": 5_200_000, "hp_plus": 7, "str_plus": 4, "int_plus": 9, "wis_plus": 9, "dex_plus": 5, "con_plus": 5, "cha_plus": 6},
+        11:{"xp_to_reach": 6_000_000, "hp_plus": 7, "str_plus": 5, "int_plus": 9, "wis_plus": 10, "dex_plus": 5, "con_plus": 6, "cha_plus": 7},
+    },
+}

--- a/mutants2/engine/classes.py
+++ b/mutants2/engine/classes.py
@@ -1,162 +1,26 @@
-"""Class defaults and progression tables.
-
-The real game contains rich per-class data.  For the purposes of the tests in
-this kata we only model the small subset that is required: starting stats for
-each class and experience/HP/stat gains for levels 2 through 11.
-
-The numbers are intentionally conservative; the exact values are less important
-than the mechanics around levelling.  Additional data can be slotted into the
-tables without changing the surrounding code.
-"""
-
+"""Class defaults loaded from data tables."""
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Dict, List
+from ..data.class_tables import BASE_LEVEL1
 
-
-@dataclass(frozen=True)
-class ClassDefaults:
-    str: int
-    int: int
-    wis: int
-    dex: int
-    con: int
-    cha: int
-    hp: int
-    ac: int
-
-
-@dataclass(frozen=True)
-class LevelProgress:
-    xp: int
-    str: int = 0
-    int: int = 0
-    wis: int = 0
-    dex: int = 0
-    con: int = 0
-    cha: int = 0
-    hp: int = 0
-
-
-# Starting values for the five playable classes.  These figures are derived from
-# reference stat pages of the original game.
-CLASS_DEFAULTS: Dict[str, ClassDefaults] = {
-    "thief": ClassDefaults(20, 12, 13, 17, 17, 14, 30, 1),
-    "priest": ClassDefaults(20, 12, 13, 17, 17, 14, 30, 1),
-    "wizard": ClassDefaults(20, 12, 13, 17, 17, 14, 30, 1),
-    "warrior": ClassDefaults(20, 12, 13, 17, 17, 14, 30, 1),
-    "mage": ClassDefaults(20, 12, 13, 17, 17, 14, 30, 1),
+_ATTR_MAP = {
+    "str": "strength",
+    "int": "intelligence",
+    "wis": "wisdom",
+    "dex": "dexterity",
+    "con": "constitution",
+    "cha": "charisma",
 }
-
-
-# Per-level progression tables.  Each entry corresponds to the XP required to
-# and the stat/HP gains granted on reaching that level.  Level numbers are
-# implicit via list position (index 0 -> level 2).
-LEVEL_TABLES: Dict[str, List[LevelProgress]] = {
-    "mage": [
-        LevelProgress(40_000, hp=5),
-        LevelProgress(120_000, hp=5),
-        LevelProgress(240_000, hp=5),
-        LevelProgress(480_000, hp=5),
-        LevelProgress(960_000, hp=5),
-        LevelProgress(1_800_000, hp=5),
-        LevelProgress(3_000_000, hp=5),
-        LevelProgress(4_500_000, hp=5),
-        LevelProgress(5_500_000, hp=5),
-        LevelProgress(6_000_000, hp=5),
-    ],
-    # Other classes use a similar placeholder progression.
-    "thief": [
-        LevelProgress(40_000, hp=5),
-        LevelProgress(120_000, hp=5),
-        LevelProgress(240_000, hp=5),
-        LevelProgress(480_000, hp=5),
-        LevelProgress(960_000, hp=5),
-        LevelProgress(1_800_000, hp=5),
-        LevelProgress(3_000_000, hp=5),
-        LevelProgress(4_500_000, hp=5),
-        LevelProgress(5_500_000, hp=5),
-        LevelProgress(6_000_000, hp=5),
-    ],
-    "priest": [
-        LevelProgress(40_000, hp=5),
-        LevelProgress(120_000, hp=5),
-        LevelProgress(240_000, hp=5),
-        LevelProgress(480_000, hp=5),
-        LevelProgress(960_000, hp=5),
-        LevelProgress(1_800_000, hp=5),
-        LevelProgress(3_000_000, hp=5),
-        LevelProgress(4_500_000, hp=5),
-        LevelProgress(5_500_000, hp=5),
-        LevelProgress(6_000_000, hp=5),
-    ],
-    "wizard": [
-        LevelProgress(40_000, hp=5),
-        LevelProgress(120_000, hp=5),
-        LevelProgress(240_000, hp=5),
-        LevelProgress(480_000, hp=5),
-        LevelProgress(960_000, hp=5),
-        LevelProgress(1_800_000, hp=5),
-        LevelProgress(3_000_000, hp=5),
-        LevelProgress(4_500_000, hp=5),
-        LevelProgress(5_500_000, hp=5),
-        LevelProgress(6_000_000, hp=5),
-    ],
-    "warrior": [
-        LevelProgress(40_000, hp=5),
-        LevelProgress(120_000, hp=5),
-        LevelProgress(240_000, hp=5),
-        LevelProgress(480_000, hp=5),
-        LevelProgress(960_000, hp=5),
-        LevelProgress(1_800_000, hp=5),
-        LevelProgress(3_000_000, hp=5),
-        LevelProgress(4_500_000, hp=5),
-        LevelProgress(5_500_000, hp=5),
-        LevelProgress(6_000_000, hp=5),
-    ],
-}
-
-
-def xp_to_level(clazz: str, xp: int) -> int:
-    """Return the level for ``xp`` in ``clazz``."""
-
-    table = LEVEL_TABLES.get(clazz, [])
-    level = 1
-    for i, row in enumerate(table, start=2):
-        if xp >= row.xp:
-            level = i
-        else:
-            break
-    if table:
-        xp11 = table[-1].xp
-        if xp >= xp11:
-            extra = (xp - xp11) // xp11
-            level = 11 + extra
-    return level
 
 
 def apply_class_defaults(player, clazz: str) -> None:
     """Reset ``player`` to the starting stats for ``clazz``."""
 
-    defaults = CLASS_DEFAULTS[clazz]
-    player.strength = defaults.str
-    player.intelligence = defaults.int
-    player.wisdom = defaults.wis
-    player.dexterity = defaults.dex
-    player.constitution = defaults.con
-    player.charisma = defaults.cha
-    player.max_hp = defaults.hp
-    player.hp = defaults.hp
-    player.ac = defaults.ac
+    base = BASE_LEVEL1[clazz]
+    for key, attr in _ATTR_MAP.items():
+        setattr(player, attr, base[key])
+    player.max_hp = base["hp"]
+    player.hp = base["hp"]
+    player.ac = base["ac"]
     player.exp = 0
     player.level = 1
-
-
-def gains_for_level(clazz: str, level: int) -> LevelProgress:
-    table = LEVEL_TABLES.get(clazz, [])
-    if not table:
-        return LevelProgress(0)
-    idx = min(level, 11) - 2
-    idx = max(0, min(idx, len(table) - 1))
-    return table[idx]

--- a/mutants2/engine/leveling.py
+++ b/mutants2/engine/leveling.py
@@ -1,32 +1,47 @@
 """Level computation and application of per-level gains."""
-
 from __future__ import annotations
 
-from .classes import xp_to_level, gains_for_level
+from ..data.class_tables import PROGRESSION
 from ..ui.theme import yellow
+from .player import class_key
+
+_ATTR_MAP = {
+    "str": "strength",
+    "int": "intelligence",
+    "wis": "wisdom",
+    "dex": "dexterity",
+    "con": "constitution",
+    "cha": "charisma",
+}
+
+
+def _xp_for_level(clazz: str, level: int) -> int:
+    table = PROGRESSION[clazz]
+    if level in table:
+        return table[level]["xp_to_reach"]
+    xp11 = table[11]["xp_to_reach"]
+    return (level - 10) * xp11
 
 
 def check_level_up(player) -> None:
-    """Recompute the player's level based on ``player.exp``.
-
-    If one or more level thresholds are crossed the appropriate stat and HP
-    gains are applied and a message is printed for each level advanced.
-    """
+    """Recompute the player's level based on ``player.exp``."""
 
     if not player.clazz:
         return
-    target = xp_to_level(player.clazz, player.exp)
-    while player.level < target:
-        player.level += 1
-        gains = gains_for_level(player.clazz, player.level)
-        player.strength += gains.str
-        player.intelligence += gains.int
-        player.wisdom += gains.wis
-        player.dexterity += gains.dex
-        player.constitution += gains.con
-        player.charisma += gains.cha
-        if gains.hp:
-            player.max_hp += gains.hp
-            player.hp += gains.hp
+    clazz = class_key(player.clazz)
+    table = PROGRESSION.get(clazz, {})
+    while True:
+        next_level = player.level + 1
+        xp_needed = _xp_for_level(clazz, next_level)
+        if player.exp < xp_needed:
+            break
+        deltas = table.get(next_level, table.get(11, {}))
+        player.max_hp += deltas.get("hp_plus", 0)
+        if player.hp > player.max_hp:
+            player.hp = player.max_hp
+        for short, attr in _ATTR_MAP.items():
+            inc = deltas.get(f"{short}_plus", 0)
+            setattr(player, attr, getattr(player, attr) + inc)
+        player.level = next_level
         print(yellow("***"))
         print(yellow(f"You advance to Level {player.level}!"))

--- a/mutants2/engine/state.py
+++ b/mutants2/engine/state.py
@@ -29,6 +29,7 @@ class CharacterProfile:
     charisma: int = 0
     ac: int = 0
     macros_name: str | None = None
+    tables_migrated: bool = True
 
 
 def profile_from_player(p: "Player") -> CharacterProfile:
@@ -50,6 +51,7 @@ def profile_from_player(p: "Player") -> CharacterProfile:
         constitution=getattr(p, "constitution", 0),
         charisma=getattr(p, "charisma", 0),
         ac=getattr(p, "ac", 0),
+        tables_migrated=True,
     )
 
 
@@ -92,6 +94,7 @@ def profile_to_raw(prof: CharacterProfile) -> dict:
         "constitution": getattr(prof, "constitution", 0),
         "charisma": getattr(prof, "charisma", 0),
         "ac": getattr(prof, "ac", 0),
+        "tables_migrated": getattr(prof, "tables_migrated", True),
         **({"macros_name": prof.macros_name} if prof.macros_name else {}),
     }
 
@@ -117,4 +120,5 @@ def profile_from_raw(data: dict) -> CharacterProfile:
         charisma=int(data.get("charisma", 0)),
         ac=int(data.get("ac", 0)),
         macros_name=data.get("macros_name"),
+        tables_migrated=bool(data.get("tables_migrated", False)),
     )

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -11,3 +11,29 @@ def print_yell(mon) -> str:
     """Return the yell line for a monster."""
     name = mon.get("name") or mon.get("key")
     return f"{name} yells at you!"
+
+
+def render_status(p) -> list[str]:
+    from ..engine.player import CLASS_DISPLAY, class_key  # local import to avoid cycle
+
+    disp = CLASS_DISPLAY.get(class_key(p.clazz or ""), p.clazz or "")
+    lines = [
+        yellow(f"Name: Vindeiatrix / Mutant {disp}"),
+        yellow("Exhaustion   : 0"),
+        yellow(
+            f"Str: {p.strength:<2}   Int: {p.intelligence:<2}   Wis: {p.wisdom:<2}"
+        ),
+        yellow(
+            f"Dex: {p.dexterity:<2}   Con: {p.constitution:<2}   Cha: {p.charisma:<2}"
+        ),
+        yellow(f"Hit Points   : {p.hp} / {p.max_hp}"),
+        yellow(f"Exp. Points  : {p.exp}           Level: {p.level}"),
+        yellow("Riblets      : 0"),
+        yellow(f"Ions         : {p.ions}"),
+        yellow(f"Wearing Armor: Nothing.  Armour Class: {p.ac}"),
+        yellow("Ready to Combat: NO ONE"),
+        yellow("Readied Spell : No spell memorized."),
+        yellow(f"Year A.D.     : {p.year}"),
+        "",
+    ]
+    return lines

--- a/tests/smoke/test_stats_page.py
+++ b/tests/smoke/test_stats_page.py
@@ -21,7 +21,7 @@ def test_stats_page(tmp_path):
         ctx.dispatch_line('status')
     out = buf.getvalue()
     assert yellow('Name: Vindeiatrix / Mutant Warrior') in out
-    assert yellow('Hit Points   : 30 / 30') in out
+    assert yellow('Hit Points   : 40 / 40') in out
     assert yellow('Ions         : 0') in out
     assert yellow('Year A.D.     : 2000') in out
     assert yellow("You are carrying the following items:  (Total Weight: 45 LB's)") in out

--- a/tests/test_progression_tables.py
+++ b/tests/test_progression_tables.py
@@ -1,0 +1,101 @@
+import json
+import pytest
+
+from mutants2.engine.player import Player
+from mutants2.engine import leveling, persistence
+from mutants2.data.class_tables import BASE_LEVEL1, PROGRESSION
+
+ATTR_MAP = {
+    "str": "strength",
+    "int": "intelligence",
+    "wis": "wisdom",
+    "dex": "dexterity",
+    "con": "constitution",
+    "cha": "charisma",
+}
+
+
+@pytest.mark.parametrize("clazz", list(BASE_LEVEL1.keys()))
+def test_level1_stats(clazz):
+    p = Player(clazz=clazz)
+    base = BASE_LEVEL1[clazz]
+    assert p.max_hp == base["hp"]
+    assert p.hp == base["hp"]
+    assert p.ac == base["ac"]
+    for short, attr in ATTR_MAP.items():
+        assert getattr(p, attr) == base[short]
+
+
+@pytest.mark.parametrize("clazz", list(BASE_LEVEL1.keys()))
+def test_progression_to_level5(clazz):
+    p = Player(clazz=clazz)
+    table = PROGRESSION[clazz]
+    target = 5
+    p.exp = table[target]["xp_to_reach"]
+    leveling.check_level_up(p)
+    assert p.level == target
+    base = BASE_LEVEL1[clazz]
+    hp_expected = base["hp"] + sum(table[l]["hp_plus"] for l in range(2, target + 1))
+    assert p.max_hp == hp_expected
+    for short, attr in ATTR_MAP.items():
+        expected = base[short] + sum(table[l][f"{short}_plus"] for l in range(2, target + 1))
+        assert getattr(p, attr) == expected
+
+
+def test_levels_beyond_eleven():
+    clazz = "mage"
+    p = Player(clazz=clazz)
+    table = PROGRESSION[clazz]
+    xp11 = table[11]["xp_to_reach"]
+    p.exp = (13 - 10) * xp11
+    leveling.check_level_up(p)
+    assert p.level == 13
+    base = BASE_LEVEL1[clazz]
+    hp_expected = base["hp"] + sum(table[l]["hp_plus"] for l in range(2, 12)) + table[11]["hp_plus"] * 2
+    assert p.max_hp == hp_expected
+    for short, attr in ATTR_MAP.items():
+        base_val = base[short]
+        total = sum(table[l][f"{short}_plus"] for l in range(2, 12))
+        total += table[11][f"{short}_plus"] * 2
+        assert getattr(p, attr) == base_val + total
+
+
+def test_migration_recomputes_stats(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    persistence.SAVE_PATH = tmp_path / ".mutants2" / "save.json"
+    table = PROGRESSION["warrior"]
+    save_data = {
+        "profiles": {
+            "warrior": {
+                "year": 2000,
+                "positions": {"2000": {"x": 0, "y": 0}},
+                "inventory": {},
+                "hp": 9999,
+                "max_hp": 9999,
+                "ions": 0,
+                "level": 3,
+                "exp": table[3]["xp_to_reach"],
+                "strength": 0,
+                "intelligence": 0,
+                "wisdom": 0,
+                "dexterity": 0,
+                "constitution": 0,
+                "charisma": 0,
+                "ac": 0,
+            }
+        },
+        "last_class": "warrior",
+    }
+    persistence.SAVE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(persistence.SAVE_PATH, "w") as fh:
+        json.dump(save_data, fh)
+    player, _, _, _, save_meta = persistence.load()
+    base = BASE_LEVEL1["warrior"]
+    table = PROGRESSION["warrior"]
+    assert player.level == 3
+    hp_expected = base["hp"] + table[2]["hp_plus"] + table[3]["hp_plus"]
+    assert player.max_hp == hp_expected
+    assert player.hp == hp_expected
+    str_expected = base["str"] + table[2]["str_plus"] + table[3]["str_plus"]
+    assert player.strength == str_expected
+    assert save_meta.profiles["warrior"].tables_migrated is True


### PR DESCRIPTION
## Summary
- define detailed level 1 stats and per-level progression tables for each class
- rework leveling, persistence and state to use the new tables with migration support
- update status rendering and tests for the new stat/HP system

## Testing
- `pytest`
- `pre-commit run --files mutants2/engine/leveling.py tests/smoke/test_stats_page.py` *(fails: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*

------
https://chatgpt.com/codex/tasks/task_e_68ba16b98fa8832b9120f60b05e35915