### PR TITLE
Add additive ion upkeep and class-based healing costs

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -28,7 +28,7 @@ from ..engine.world import ALLOWED_CENTURIES
 from ..ui.help import MACROS_HELP, ABBREVIATIONS_NOTE, COMMANDS_HELP, USAGE
 from ..ui.strings import GET_WHAT, DROP_WHAT
 from ..ui.theme import red, SEP, yellow, cyan, white
-from ..data.config import ION_TRAVEL_COST
+from ..data.config import ION_TRAVEL_COST, HEAL_K
 from ..ui.render import render_help_hint, render_status
 from .input import gerundize
 
@@ -433,16 +433,18 @@ def make_context(p, w, save, *, dev: bool = False):
         print(f"You rest and recover. (HP: {p.hp}/{p.max_hp})")
 
     def handle_heal() -> None:
+        k = HEAL_K.get(class_key(p.clazz or ""), 0)
+        heal_amount = p.level + 5
+        cost = k * p.level
+        if p.ions < cost:
+            print(yellow("***"))
+            print(yellow("You don't have enough ions to heal!"))
+            return
         if p.hp >= p.max_hp:
             print(yellow("***"))
             print(yellow("Nothing happens!"))
             return
-        if p.ions < 1000:
-            print(yellow("***"))
-            print(yellow("You don't have enough ions to heal!"))
-            return
-        heal_amount = 6 + (p.level - 1)
-        p.ions -= 1000
+        p.ions -= cost
         p.hp = min(p.max_hp, p.hp + heal_amount)
         print(yellow("***"))
         print(yellow(f"Your body glows as it heals {heal_amount} points!"))

--- a/mutants2/data/config.py
+++ b/mutants2/data/config.py
@@ -6,3 +6,11 @@ ION_BASE = {
     "warrior": 100,
     "mage": 47,
 }
+
+HEAL_K = {
+    "thief": 200,
+    "priest": 750,
+    "wizard": 1000,
+    "warrior": 750,
+    "mage": 1200,
+}

--- a/mutants2/engine/loop.py
+++ b/mutants2/engine/loop.py
@@ -8,16 +8,12 @@ from .player import class_key
 
 
 def ion_upkeep(player, world, save, context=None, *, now: float | None = None, max_ticks: int = 60) -> None:
-    """Apply ion upkeep based on elapsed time.
-
-    This subtracts ions every 10 seconds according to class and level.
-    If ions run out, the player loses HP equal to their level each tick.
-    """
+    """Apply ion upkeep and starvation based on elapsed time."""
 
     current = time.time() if now is None else now
-    last = getattr(save, "last_ion_tick", None)
+    last = getattr(save, "last_upkeep_tick", None)
     if last is None:
-        save.last_ion_tick = current
+        save.last_upkeep_tick = current
         return
     elapsed = current - last
     ticks = int(elapsed // 10)
@@ -25,20 +21,20 @@ def ion_upkeep(player, world, save, context=None, *, now: float | None = None, m
         return
     if ticks > max_ticks:
         ticks = max_ticks
-    save.last_ion_tick = last + ticks * 10
     clazz = class_key(player.clazz or "")
     base = ION_BASE.get(clazz, 0)
     for _ in range(ticks):
+        last += 10
         if player.level > 1:
-            mult = 2 ** ((player.level - 2) // 2)
-            consume = base * mult
+            steps = 1 + ((player.level - 2) // 2)
+            consume = base * steps
         else:
             consume = 0
         if player.ions >= consume:
             player.ions -= consume
         else:
             player.ions = 0
-        if player.ions == 0:
+        if player.ions == 0 and not player.is_dead():
             player.hp = max(0, player.hp - player.level)
             print(yellow("You're starving for IONS!"))
             if player.hp <= 0:
@@ -50,3 +46,5 @@ def ion_upkeep(player, world, save, context=None, *, now: float | None = None, m
                     context._arrivals_this_tick = []
                     context._needs_render = False
                     context._suppress_room_render = True
+                break
+    save.last_upkeep_tick = last

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -34,7 +34,7 @@ class Save:
     profiles: Dict[str, CharacterProfile] = field(default_factory=dict)
     # ``fake_today_override`` is session-only and not persisted
     fake_today_override: str | None = None
-    last_ion_tick: float = field(default_factory=lambda: time.time())
+    last_upkeep_tick: float = field(default_factory=lambda: time.time())
 
 
 SAVE_PATH = Path(os.path.expanduser("~/.mutants2/save.json"))
@@ -202,7 +202,9 @@ def load() -> tuple[
             last_topup_date=data.get("last_topup_date"),
             last_class=last_class,
             profiles=profiles,
-            last_ion_tick=float(data.get("last_ion_tick", time.time())),
+            last_upkeep_tick=float(
+                data.get("last_upkeep_tick", data.get("last_ion_tick", time.time()))
+            ),
         )
 
         if not active_class and profiles:
@@ -258,7 +260,7 @@ def save(player: Player, world: World, save_meta: Save) -> None:
                 for k, v in save_meta.profiles.items()
             },
             "last_class": save_meta.last_class,
-            "last_ion_tick": save_meta.last_ion_tick,
+            "last_upkeep_tick": save_meta.last_upkeep_tick,
             "ground": {
                 f"{y},{x},{yy}": (items[0] if len(items) == 1 else items)
                 for (y, x, yy), items in world.ground.items()

--- a/tests/test_upkeep.py
+++ b/tests/test_upkeep.py
@@ -1,0 +1,51 @@
+import io
+import contextlib
+import re
+
+from mutants2.engine import loop, world as world_mod, persistence
+from mutants2.engine.player import Player
+
+
+def run_upkeep(p, *, now, save=None):
+    w = world_mod.World(global_seed=42)
+    if save is None:
+        save = persistence.Save(global_seed=42, last_upkeep_tick=0)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        loop.ion_upkeep(p, w, save, now=now)
+    out = re.sub(r"\x1b\[[0-9;]*m", "", buf.getvalue())
+    return out, p, save
+
+
+def test_additive_upkeep_examples():
+    p = Player(year=2000, clazz="Thief", level=2, ions=1000, hp=20, max_hp=20)
+    out, p, save = run_upkeep(p, now=10)
+    assert p.ions == 750
+    assert save.last_upkeep_tick == 10
+    p2 = Player(year=2000, clazz="Mage", level=12, ions=1000, hp=20, max_hp=20)
+    out2, p2, save2 = run_upkeep(p2, now=10)
+    assert p2.ions == 718
+    assert save2.last_upkeep_tick == 10
+
+
+def test_starvation_tick_cadence():
+    p = Player(year=2000, clazz="Warrior", level=5, ions=0, hp=20, max_hp=20)
+    save = persistence.Save(global_seed=42, last_upkeep_tick=0)
+    out1, p, save = run_upkeep(p, now=10, save=save)
+    assert "You're starving for IONS!" in out1
+    assert p.hp == 15
+    out2, p, save = run_upkeep(p, now=15, save=save)
+    assert "You're starving for IONS!" not in out2
+    assert p.hp == 15
+    out3, p, save = run_upkeep(p, now=20, save=save)
+    assert "You're starving for IONS!" in out3
+    assert p.hp == 10
+
+
+def test_starvation_death_stops():
+    p = Player(year=2000, clazz="Warrior", level=5, ions=0, hp=5, max_hp=5)
+    save = persistence.Save(global_seed=42, last_upkeep_tick=0)
+    out, p, save = run_upkeep(p, now=25, save=save)
+    assert "You have died." in out
+    assert p.hp == p.max_hp
+    assert save.last_upkeep_tick == 10


### PR DESCRIPTION
## Summary
- implement class-level heal cost and heal amount scaling
- switch ion upkeep to additive model with starvation ticks
- persist last upkeep tick in saves and add tests for new mechanics

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bac16406a8832bb56100722d13c600