### PR TITLE
Fix ion upkeep to additive class-based scaling

### DIFF
--- a/mutants2/data/config.py
+++ b/mutants2/data/config.py
@@ -2,9 +2,9 @@ ION_TRAVEL_COST = 10_000
 ION_BASE = {
     "thief": 250,
     "priest": 150,
-    "wizard": 200,
-    "warrior": 100,
-    "mage": 47,
+    "wizard": 150,
+    "warrior": 200,
+    "mage": 250,
 }
 
 HEAL_K = {

--- a/mutants2/engine/loop.py
+++ b/mutants2/engine/loop.py
@@ -7,6 +7,17 @@ from ..ui.theme import yellow
 from .player import class_key
 
 
+def ion_upkeep_per_tick(player) -> int:
+    """Return ions to consume for a single 10 second tick."""
+
+    if player.level <= 1:
+        return 0
+    clazz = class_key(player.clazz or "")
+    base = ION_BASE.get(clazz, 0)
+    steps = 1 + ((player.level - 2) // 2)
+    return base * steps
+
+
 def ion_upkeep(player, world, save, context=None, *, now: float | None = None, max_ticks: int = 60) -> None:
     """Apply ion upkeep and starvation based on elapsed time."""
 
@@ -21,15 +32,9 @@ def ion_upkeep(player, world, save, context=None, *, now: float | None = None, m
         return
     if ticks > max_ticks:
         ticks = max_ticks
-    clazz = class_key(player.clazz or "")
-    base = ION_BASE.get(clazz, 0)
     for _ in range(ticks):
         last += 10
-        if player.level > 1:
-            steps = 1 + ((player.level - 2) // 2)
-            consume = base * steps
-        else:
-            consume = 0
+        consume = ion_upkeep_per_tick(player)
         if player.ions >= consume:
             player.ions -= consume
         else:

--- a/tests/test_upkeep.py
+++ b/tests/test_upkeep.py
@@ -24,7 +24,8 @@ def test_additive_upkeep_examples():
     assert save.last_upkeep_tick == 10
     p2 = Player(year=2000, clazz="Mage", level=12, ions=1000, hp=20, max_hp=20)
     out2, p2, save2 = run_upkeep(p2, now=10)
-    assert p2.ions == 718
+    assert p2.ions == 0
+    assert "You're starving for IONS!" in out2
     assert save2.last_upkeep_tick == 10
 
 


### PR DESCRIPTION
## Summary
- Correct ion upkeep bases for all classes
- Implement `ion_upkeep_per_tick` with additive scaling every two levels
- Update upkeep tests to match new starvation behavior

## Testing
- `pytest`
- `python -m pip install pre-commit` *(failed: command not found: pre-commit)*
- `python -m pre_commit run --files mutants2/data/config.py mutants2/engine/loop.py tests/test_upkeep.py` *(failed: RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.11')*


------
https://chatgpt.com/codex/tasks/task_e_68bac8d95824832bb3345fafb729fe07