### PR TITLE
Realtime ion starvation tick and debug command rename

### DIFF
--- a/mutants2/engine/loop.py
+++ b/mutants2/engine/loop.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import time
+import threading
 
 from ..data.config import ION_BASE
-from ..ui.theme import yellow
+from ..ui.theme import yellow, SEP
 from .player import class_key
+
+TICK_SECONDS = 10.0
+REALTIME_TICK_POLL = 1.0
 
 
 def ion_upkeep_per_tick(player) -> int:
-    """Return ions to consume for a single 10 second tick."""
+    """Return ions to consume for a single upkeep tick."""
 
     if player.level <= 1:
         return 0
@@ -18,38 +22,93 @@ def ion_upkeep_per_tick(player) -> int:
     return base * steps
 
 
-def ion_upkeep(player, world, save, context=None, *, now: float | None = None, max_ticks: int = 60) -> None:
-    """Apply ion upkeep and starvation based on elapsed time."""
+def process_upkeep_and_starvation(player, world, save, context=None) -> bool:
+    """Consume upkeep and apply starvation/death effects for one tick.
 
-    current = time.time() if now is None else now
+    Returns ``True`` if the player died during this tick.
+    """
+
+    consume = ion_upkeep_per_tick(player)
+    if player.ions >= consume:
+        player.ions -= consume
+    else:
+        player.ions = 0
+    died = False
+    if player.ions == 0 and not player.is_dead():
+        player.hp = max(0, player.hp - player.level)
+        print(SEP)
+        print(yellow("You're starving for IONS!"))
+        if player.hp <= 0:
+            died = True
+            print("You have died.")
+            player.heal_full()
+            player.positions[player.year] = (0, 0)
+            world.reset_aggro_in_year(player.year)
+            if context is not None:
+                context._arrivals_this_tick = []
+                context._needs_render = False
+                context._suppress_room_render = True
+    return died
+
+
+def maybe_process_upkeep(player, world, save, context=None, *, now: float | None = None) -> None:
+    """Process at most one owed upkeep/starvation tick based on ``last_upkeep_tick``."""
+
+    current = time.monotonic() if now is None else now
+    last = getattr(save, "last_upkeep_tick", None)
+    if last is None:
+        save.last_upkeep_tick = current
+        return
+    ticks = int((current - last) // TICK_SECONDS)
+    if ticks >= 1:
+        save.last_upkeep_tick += TICK_SECONDS
+        process_upkeep_and_starvation(player, world, save, context)
+
+
+def ion_upkeep(player, world, save, context=None, *, now: float | None = None, max_ticks: int | None = None) -> None:
+    """Catch up on ion upkeep immediately (used for tests/offline processing)."""
+
+    current = time.monotonic() if now is None else now
     last = getattr(save, "last_upkeep_tick", None)
     if last is None:
         save.last_upkeep_tick = current
         return
     elapsed = current - last
-    ticks = int(elapsed // 10)
+    ticks = int(elapsed // TICK_SECONDS)
     if ticks <= 0:
         return
+    if max_ticks is None:
+        max_ticks = getattr(save, "max_catchup_ticks", 60)
     if ticks > max_ticks:
         ticks = max_ticks
     for _ in range(ticks):
-        last += 10
-        consume = ion_upkeep_per_tick(player)
-        if player.ions >= consume:
-            player.ions -= consume
-        else:
-            player.ions = 0
-        if player.ions == 0 and not player.is_dead():
-            player.hp = max(0, player.hp - player.level)
-            print(yellow("You're starving for IONS!"))
-            if player.hp <= 0:
-                print("You have died.")
-                player.heal_full()
-                player.positions[player.year] = (0, 0)
-                world.reset_aggro_in_year(player.year)
-                if context is not None:
-                    context._arrivals_this_tick = []
-                    context._needs_render = False
-                    context._suppress_room_render = True
-                break
-    save.last_upkeep_tick = last
+        save.last_upkeep_tick += TICK_SECONDS
+        if process_upkeep_and_starvation(player, world, save, context):
+            break
+
+
+def start_realtime_tick(player, world, save, context=None):
+    """Start a background thread that applies upkeep in real time."""
+
+    stop_event = threading.Event()
+
+    def _run() -> None:
+        while not stop_event.is_set():
+            time.sleep(REALTIME_TICK_POLL)
+            current = time.monotonic()
+            ticks = int((current - save.last_upkeep_tick) // TICK_SECONDS)
+            if ticks >= 1:
+                save.last_upkeep_tick += TICK_SECONDS
+                process_upkeep_and_starvation(player, world, save, context)
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+    return stop_event, thread
+
+
+def stop_realtime_tick(handle) -> None:
+    """Stop a previously started realtime tick thread."""
+
+    stop_event, thread = handle
+    stop_event.set()
+    thread.join(timeout=1)

--- a/tests/smoke/test_heal_and_debug_and_menu.py
+++ b/tests/smoke/test_heal_and_debug_and_menu.py
@@ -172,3 +172,25 @@ def test_debug_item_and_mon_count():
     out2, w2, p2 = run_debug("debug mon count", setup=setup_mon)
     lines2 = [line for line in out2.splitlines() if line]
     assert lines2[-1] == f"Monsters in year {p2.year}: 2"
+
+
+def test_debug_set_ion():
+    out, w, p = run_debug("debug set ion 123")
+    lines = [line for line in out.splitlines() if line]
+    assert lines[-1] == "Ions set to 123."
+    assert p.ions == 123
+
+
+def test_debug_ion_set_alias_once():
+    save = persistence.Save(global_seed=42)
+    w = world_mod.World(global_seed=42)
+    w.year(2000)
+    p = Player(year=2000, clazz="Warrior")
+    ctx = make_context(p, w, save, dev=True)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line("debug ion set 7")
+        ctx.dispatch_line("debug ion set 8")
+    out = re.sub(r"\x1b\[[0-9;]*m", "", buf.getvalue())
+    assert out.count("debug ion set is deprecated") == 1
+    assert p.ions == 8


### PR DESCRIPTION
## Summary
- add realtime background upkeep ticking and starvation handling
- persist monotonic upkeep timestamp and limit catch-up
- rename `debug ion set` to `debug set ion` with alias and warning

## Testing
- `pytest tests/test_upkeep.py tests/smoke/test_heal_and_debug_and_menu.py tests/test_persistence.py`

------
https://chatgpt.com/codex/tasks/task_e_68bae153e75c832b9810f151f1561d88