### PR TITLE
Fix starvation cadence and debug command naming

### DIFF
--- a/mutants2/__main__.py
+++ b/mutants2/__main__.py
@@ -55,7 +55,7 @@ def main() -> None:
         print(line)
 
     ctx = make_context(p, w, save, dev=dev)
-    tick_handle = loop.start_realtime_tick(p, w, save, ctx)
+    ctx.tick_handle = loop.start_realtime_tick(p, w, save, ctx)
     try:
         while True:
             try:
@@ -66,7 +66,7 @@ def main() -> None:
             if ctx.dispatch_line(line):
                 break
     finally:
-        loop.stop_realtime_tick(tick_handle)
+        loop.stop_realtime_tick(getattr(ctx, "tick_handle", None))
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -35,7 +35,7 @@ class Save:
     # ``fake_today_override`` is session-only and not persisted
     fake_today_override: str | None = None
     last_upkeep_tick: float = field(default_factory=lambda: time.monotonic())
-    max_catchup_ticks: int = 60
+    max_catchup_ticks: int = 6
 
 
 SAVE_PATH = Path(os.path.expanduser("~/.mutants2/save.json"))
@@ -208,7 +208,7 @@ def load() -> tuple[
             last_class=last_class,
             profiles=profiles,
             last_upkeep_tick=time.monotonic() - max(0.0, now_wall - last_wall),
-            max_catchup_ticks=int(data.get("max_catchup_ticks", 60)),
+            max_catchup_ticks=int(data.get("max_catchup_ticks", 6)),
         )
 
         if not active_class and profiles:


### PR DESCRIPTION
## Summary
- Gate upkeep/starvation ticks behind active game context and run them on a true 10‑second cadence
- Pause realtime upkeep when entering the class menu and resume after selection
- Default catch-up window to one minute and expose `debug set ion` as canonical, with `debug ion set` deprecated

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baf21f1d9c832b9e8d6f46eba10142