### PR TITLE
Robust in-game upkeep scheduler with strict gating

### DIFF
--- a/mutants2/__main__.py
+++ b/mutants2/__main__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import os
 import atexit
+import time
 
 
 def main() -> None:
@@ -41,7 +42,7 @@ def main() -> None:
 
     if p.clazz is None:
         w.reset_all_aggro()
-        class_menu(p, w, save, in_game=False)
+        class_menu(p, w, save, None, in_game=False)
 
     placed = daily_topup_if_needed(w, p, save)
     if dev and placed:
@@ -54,6 +55,7 @@ def main() -> None:
     for line in yells:
         print(line)
 
+    save.next_upkeep_tick = time.monotonic() + loop.TICK_SECONDS
     ctx = make_context(p, w, save, dev=dev)
     ctx.tick_handle = loop.start_realtime_tick(p, w, save, ctx)
     try:

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -35,6 +35,7 @@ class Save:
     # ``fake_today_override`` is session-only and not persisted
     fake_today_override: str | None = None
     last_upkeep_tick: float = field(default_factory=lambda: time.monotonic())
+    next_upkeep_tick: float | None = None  # monotonic deadline for next 10s tick
     max_catchup_ticks: int = 6
 
 

--- a/tests/test_realtime_tick_scheduler.py
+++ b/tests/test_realtime_tick_scheduler.py
@@ -1,0 +1,88 @@
+import contextlib
+import io
+from types import SimpleNamespace
+
+from mutants2.engine import loop, world as world_mod, persistence
+from mutants2.engine.player import Player
+
+
+class FakeTime:
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self) -> float:  # pragma: no cover - simple helper
+        return self.now
+
+
+def test_scheduler_and_gating(monkeypatch):
+    fake = FakeTime()
+    monkeypatch.setattr(loop, "time", fake)
+
+    p = Player(year=2000, clazz="Warrior", level=6, ions=0, hp=30, max_hp=30)
+    w = world_mod.World(global_seed=1)
+    save = persistence.Save(global_seed=1)
+    ctx = SimpleNamespace(player=p, world=w, in_game=False, tick_handle=None)
+
+    save.next_upkeep_tick = 0.0
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        loop.maybe_process_upkeep(p, w, save, ctx, now=fake.monotonic())
+    assert p.hp == 30
+    assert save.next_upkeep_tick == 0.0
+
+    ctx.in_game = True
+    with contextlib.redirect_stdout(buf):
+        loop.maybe_process_upkeep(p, w, save, ctx, now=fake.monotonic())
+    assert p.hp == 24
+    assert save.next_upkeep_tick == 10.0
+
+    for t in range(1, 10):
+        fake.now = t
+        loop.maybe_process_upkeep(p, w, save, ctx)
+    assert p.hp == 24
+
+    fake.now = 10
+    loop.maybe_process_upkeep(p, w, save, ctx)
+    assert p.hp == 18
+    assert save.next_upkeep_tick == 20.0
+
+    fake.now = 60
+    loop.maybe_process_upkeep(p, w, save, ctx)
+    assert p.hp == 12
+    assert save.next_upkeep_tick == 70.0
+
+    ctx.tick_handle = object()
+    fake.now = 70
+    loop.maybe_process_upkeep(p, w, save, ctx)
+    assert p.hp == 12
+
+
+def test_start_realtime_tick_single_thread(monkeypatch):
+    p = Player(year=2000, clazz="Warrior")
+    w = world_mod.World(global_seed=1)
+    save = persistence.Save(global_seed=1)
+    ctx = SimpleNamespace(player=p, world=w, in_game=True, tick_handle=None)
+
+    calls: list[int] = []
+
+    class DummyThread:
+        def __init__(self, *a, **kw):
+            calls.append(1)
+
+        def start(self) -> None:  # pragma: no cover - no-op
+            pass
+
+        def join(self, timeout=None) -> None:  # pragma: no cover - no-op
+            pass
+
+    monkeypatch.setattr(loop.threading, "Thread", DummyThread)
+
+    handle1 = loop.start_realtime_tick(p, w, save, ctx)
+    ctx.tick_handle = handle1
+    assert len(calls) == 1
+
+    handle2 = loop.start_realtime_tick(p, w, save, ctx)
+    assert handle2 is handle1
+    assert len(calls) == 1
+
+    loop.stop_realtime_tick(handle1)


### PR DESCRIPTION
## Summary
- gate upkeep logic on a strict `context.in_game` flag
- replace owed-tick math with a monotonic `next_upkeep_tick` scheduler
- manage realtime tick lifecycle around class menu entry/exit and add scheduler tests

## Testing
- `pytest`
- `pytest tests/test_realtime_tick_scheduler.py`


------
https://chatgpt.com/codex/tasks/task_e_68baf6a5fa1c832b8b3c87d3a0e00bc6