### PR TITLE
Expand time travel to year 3000 with step-based ion cost

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -30,7 +30,7 @@ from ..engine.gen import (
 )
 from ..engine.macros import MacroStore
 from ..engine.types import Direction
-from ..engine.world import ALLOWED_CENTURIES
+from ..engine.world import ALLOWED_CENTURIES, LOWEST_CENTURY, HIGHEST_CENTURY
 from ..ui.help import MACROS_HELP, ABBREVIATIONS_NOTE, COMMANDS_HELP, USAGE
 from ..ui.strings import GET_WHAT, DROP_WHAT
 from ..ui.theme import red, SEP, yellow, cyan, white
@@ -294,18 +294,20 @@ def make_context(p, w, save, *, dev: bool = False):
             print("Invalid year.")
             context._suppress_room_render = True
             return False
-        if year_input < ALLOWED_CENTURIES[0] or year_input > ALLOWED_CENTURIES[-1]:
-            print(yellow("You can only travel from year 2000 to 2200!"))
-            context._needs_render = False
-            context._suppress_room_render = True
-            return False
-        if p.ions < ION_TRAVEL_COST:
-            print(yellow("You don't have enough ions to travel!"))
+        if year_input < LOWEST_CENTURY or year_input > HIGHEST_CENTURY:
+            print(yellow("You can only travel from year 2000 to 3000!"))
             context._needs_render = False
             context._suppress_room_render = True
             return False
         target = max(c for c in ALLOWED_CENTURIES if c <= year_input)
-        p.ions -= ION_TRAVEL_COST
+        steps = abs(target - p.year) // 100
+        cost = ION_TRAVEL_COST * steps
+        if p.ions < cost:
+            print(yellow("You don't have enough ions to travel!"))
+            context._needs_render = False
+            context._suppress_room_render = True
+            return False
+        p.ions -= cost
         p.travel(w, target)
         print(white(f"ZAAAAPPPPP!! You've been sent to the year {target} A.D."))
         context._suppress_room_render = True

--- a/mutants2/data/config.py
+++ b/mutants2/data/config.py
@@ -1,4 +1,6 @@
-ION_TRAVEL_COST = 10_000
+# Ion cost per century step when travelling through time.  The final travel
+# cost is this value multiplied by the number of century steps traversed.
+ION_TRAVEL_COST = 3_000
 ION_BASE = {
     "thief": 250,
     "priest": 150,

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -34,7 +34,22 @@ Coordinate = Tuple[int, int]
 
 GRID_MIN = -15
 GRID_MAX = 15
-ALLOWED_CENTURIES = [2000, 2100, 2200]
+# Centuries the player can travel between.  Each century has an independent
+# world state and uses the same generation parameters as the others.
+ALLOWED_CENTURIES = [
+    2000,
+    2100,
+    2200,
+    2300,
+    2400,
+    2500,
+    2600,
+    2700,
+    2800,
+    2900,
+    3000,
+]
+LOWEST_CENTURY, HIGHEST_CENTURY = 2000, 3000
 
 
 def in_bounds(x: int, y: int) -> bool:

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -97,8 +97,8 @@ USAGE = {
     "travel": [
         "You can travel through time by typing:",
         "TRAVEL [year]",
-        "The years you can travel from is 2000 to 2200 A.D. Your travel will be",
-        "rounded off to the closest century, and you'll be sent into a new world.",
+        "The years you can travel from is 2000 to 3000 A.D. Your travel will be",
+        "rounded down to the closest century, and you'll be sent into a new world.",
     ],
     "convert": [
         "You may convert items into ions. Each item converts into",

--- a/tests/smoke/test_travel_convert_and_items.py
+++ b/tests/smoke/test_travel_convert_and_items.py
@@ -37,14 +37,14 @@ def test_convert_gibberish(cli_runner):
 
 
 def test_travel_rounding_and_stats(cli_runner):
-    out = cli_runner.run_commands(['tra 2149', 'status'])
-    assert white("ZAAAAPPPPP!! You've been sent to the year 2100 A.D.") in out
-    assert 'Year A.D.     : 2100' in out
+    out = cli_runner.run_commands(['tra 2345', 'status'])
+    assert white("ZAAAAPPPPP!! You've been sent to the year 2300 A.D.") in out
+    assert 'Year A.D.     : 2300' in out
 
 
 def test_travel_out_of_range(cli_runner):
     out = cli_runner.run_commands(['travel 23452353'])
-    assert yellow('You can only travel from year 2000 to 2200!') in out
+    assert yellow('You can only travel from year 2000 to 3000!') in out
 
 
 def test_command_usage_blocks(cli_runner):

--- a/tests/test_travel_cost.py
+++ b/tests/test_travel_cost.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import contextlib
+from io import StringIO
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence
+from mutants2.engine.world import World
+from mutants2.engine.player import Player
+from mutants2.ui.theme import white, yellow
+
+
+def run(commands: list[str], *, ions: int = 0, start_year: int = 2000, start_pos: tuple[int, int] = (0, 0)):
+    w = World()
+    w.year(start_year)
+    p = Player(year=start_year, ions=ions)
+    p.positions[start_year] = start_pos
+    save = persistence.Save()
+    ctx = make_context(p, w, save)
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        for cmd in commands:
+            ctx.dispatch_line(cmd)
+    return buf.getvalue(), p
+
+
+def test_travel_cost_deducts_per_century():
+    out, p = run(["travel 2500"], ions=20_000)
+    assert white("ZAAAAPPPPP!! You've been sent to the year 2500 A.D.") in out
+    # 5 century steps -> 15,000 ion cost
+    assert p.year == 2500 and p.ions == 5_000
+
+
+def test_travel_costs_when_travelling_backward():
+    out, p = run(["travel 2300"], ions=20_000, start_year=2800)
+    assert white("ZAAAAPPPPP!! You've been sent to the year 2300 A.D.") in out
+    assert p.year == 2300 and p.ions == 5_000
+
+
+def test_travel_insufficient_ions_blocks():
+    out, p = run(["travel 2500"], ions=14_000)
+    assert yellow("You don't have enough ions to travel!") in out
+    assert p.year == 2000 and p.ions == 14_000
+
+
+def test_same_century_travel_free_and_resets_position():
+    out, p = run(["east", "travel 2700"], ions=5_000, start_year=2700, start_pos=(1, 0))
+    assert white("ZAAAAPPPPP!! You've been sent to the year 2700 A.D.") in out
+    assert p.ions == 5_000
+    assert p.positions[2700] == (0, 0)
+

--- a/tests/test_world_map.py
+++ b/tests/test_world_map.py
@@ -1,9 +1,9 @@
-from mutants2.engine.world import World, GRID_MIN, GRID_MAX
+from mutants2.engine.world import World, GRID_MIN, GRID_MAX, ALLOWED_CENTURIES
 
 
 def test_world_maps_have_origin_and_exits():
     w = World()
-    for year in (2000, 2100, 2200):
+    for year in ALLOWED_CENTURIES:
         grid = w.year(year).grid
         assert grid.width == GRID_MAX - GRID_MIN and grid.height == GRID_MAX - GRID_MIN
         assert grid.is_walkable(0, 0)


### PR DESCRIPTION
## Summary
- allow travel to centuries up to 3000 with per-century state isolation
- charge 3,000 ions per century step travelled
- document new travel range and rounding in help text
- add tests for new travel cost and expanded centuries

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bafc615d58832b9b25b52a6c32ed2e