### PR TITLE
Implement inventory and ground limits with swap mechanics

### DIFF
--- a/mutants2/engine/items.py
+++ b/mutants2/engine/items.py
@@ -59,6 +59,7 @@ __all__ = [
     "describe",
     "article_name",
     "stack_for_render",
+    "stack_plain",
     "resolve_key_prefix",
     "display_name",
 ]
@@ -150,6 +151,23 @@ def stack_for_render(item_names: list[str]) -> list[str]:
         else:
             tokens.append(article_name(name))
             tokens.append(f"{article_name(name)} ({counts[name]-1})")
+        counts[name] = 0
+    if tokens:
+        tokens[-1] = tokens[-1] + "."
+    return tokens
+
+
+def stack_plain(item_names: list[str]) -> list[str]:
+    counts = collections.Counter(item_names)
+    tokens: list[str] = []
+    for name in item_names:
+        if counts[name] == 0:
+            continue
+        if counts[name] == 1:
+            tokens.append(name)
+        else:
+            tokens.append(name)
+            tokens.append(f"{name} ({counts[name]-1})")
         counts[name] = 0
     if tokens:
         tokens[-1] = tokens[-1] + "."

--- a/tests/smoke/test_stats_page.py
+++ b/tests/smoke/test_stats_page.py
@@ -5,7 +5,7 @@ import io
 from mutants2.engine import persistence, world as world_mod
 from mutants2.engine.player import Player
 from mutants2.cli.shell import make_context
-from mutants2.ui.theme import yellow, cyan
+from mutants2.ui.theme import yellow, white
 
 
 def test_stats_page(tmp_path):
@@ -25,4 +25,4 @@ def test_stats_page(tmp_path):
     assert yellow('Ions         : 0') in out
     assert yellow('Year A.D.     : 2000') in out
     assert yellow("You are carrying the following items:  (Total Weight: 45 LB's)") in out
-    assert cyan('Ion-Decay, Ion-Decay, Gold-Chunk.') in out
+    assert white('Ion-Decay, Ion-Decay (1), Gold-Chunk.') in out

--- a/tests/test_item_limits.py
+++ b/tests/test_item_limits.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import contextlib
+from io import StringIO
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence
+from mutants2.engine.player import Player, INVENTORY_LIMIT
+from mutants2.engine.world import World
+from mutants2.engine import items
+from mutants2.ui.theme import yellow
+
+
+def run(cmds: list[str], *, p: Player, w: World):
+    save = persistence.Save()
+    ctx = make_context(p, w, save)
+    buf = StringIO()
+    with contextlib.redirect_stdout(buf):
+        for cmd in cmds:
+            ctx.dispatch_line(cmd)
+    return buf.getvalue()
+
+
+def test_inventory_limit_swap():
+    inv_keys = [
+        "ion_decay",
+        "gold_chunk",
+        "cheese",
+        "light_spear",
+        "monster_bait",
+        "nuclear_thong",
+        "ion_pack",
+        "ion_booster",
+        "nuclear_waste",
+        "cigarette_butt",
+    ]
+    p = Player()
+    for k in inv_keys:
+        p.inventory[k] = 1
+    w = World({(2000, 0, 0): ["bottle_cap"]}, {2000}, global_seed=123)
+
+    out = run(["get Bottle-Cap"], p=p, w=w)
+
+    assert sum(p.inventory.values()) == INVENTORY_LIMIT
+    ground_items = w.items_on_ground(2000, 0, 0)
+    assert len(ground_items) == 1
+    victim_name = ground_items[0].name
+    assert yellow("***") in out
+    assert yellow(f"The {victim_name} fell out of your sack!") in out
+    assert out.index(f"The {victim_name} fell out of your sack!") < out.index(
+        "You pick up Bottle-Cap."
+    )
+
+
+def test_ground_limit_swap():
+    ground_keys = [
+        "ion_decay",
+        "gold_chunk",
+        "cheese",
+        "light_spear",
+        "monster_bait",
+        "nuclear_thong",
+    ]
+    w = World({(2000, 0, 0): ground_keys}, {2000}, global_seed=123)
+    p = Player()
+    p.inventory["cigarette_butt"] = 1
+
+    out = run(["drop Cigarette-Butt"], p=p, w=w)
+
+    assert len(w.items_on_ground(2000, 0, 0)) == 6
+    assert sum(p.inventory.values()) == 1
+    gift_key = next(iter(p.inventory.keys()))
+    gift_name = items.REGISTRY[gift_key].name
+    assert yellow("***") in out
+    assert yellow(f"{items.article_name(gift_name)} has magically appeared in your hand!") in out
+    assert out.index("You drop Cigarette-Butt.") < out.index(
+        f"{items.article_name(gift_name)} has magically appeared in your hand!"
+    )
+

--- a/tests/test_items_basic.py
+++ b/tests/test_items_basic.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from mutants2.engine import persistence
 from mutants2.engine.world import World
 from mutants2.engine.player import Player
-from mutants2.ui.theme import cyan
+from mutants2.ui.theme import white
 
 
 def _ensure_profile(tmp_path):
@@ -82,7 +82,7 @@ def test_pickup_and_drop_roundtrip(tmp_path):
     result = _run_game(['get Ion-Decay', 'look', 'inventory', 'drop Ion-Decay', 'look', 'inventory', 'exit'], tmp_path)
     out = result.stdout
     assert 'You pick up Ion-Decay.' in out
-    assert cyan('Ion-Decay.') in out
+    assert white('Ion-Decay.') in out
     assert 'You drop Ion-Decay.' in out
     after = out.split('You drop Ion-Decay.')[-1]
     assert 'On the ground lies:' in after and 'Ion-Decay' in after
@@ -98,7 +98,7 @@ def test_inventory_rendering(tmp_path):
     save = persistence.Save()
     persistence.save(p, w, save)
     result = _run_game(['inventory', 'exit'], tmp_path)
-    assert cyan('Ion-Decay, Ion-Decay, Gold-Chunk.') in result.stdout
+    assert white('Ion-Decay, Ion-Decay (1), Gold-Chunk.') in result.stdout
 
 
 def test_persistence_inventory_and_ground(tmp_path):
@@ -111,7 +111,7 @@ def test_persistence_inventory_and_ground(tmp_path):
     _run_game(['get Ion-Decay', 'east', 'exit'], tmp_path)
     result = _run_game(['inventory', 'west', 'look', 'exit'], tmp_path)
     out = result.stdout
-    assert cyan('Ion-Decay.') in out
+    assert white('Ion-Decay.') in out
     looked = out.split('look')[-1]
     assert 'Ion-Decay' not in looked
 
@@ -124,4 +124,4 @@ def test_name_matching_case_insensitive(tmp_path):
     save = persistence.Save()
     persistence.save(p, w, save)
     result = _run_game(['get ion-decay', 'drop ion-decay', 'get Ion-Decay', 'inventory', 'exit'], tmp_path)
-    assert cyan('Ion-Decay.') in result.stdout
+    assert white('Ion-Decay.') in result.stdout

--- a/tests/test_player_ions_inventory_weight.py
+++ b/tests/test_player_ions_inventory_weight.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from mutants2.engine import persistence
 from mutants2.engine.player import Player
 from mutants2.engine.world import World
-from mutants2.ui.theme import yellow, cyan
+from mutants2.ui.theme import yellow, white
 
 
 def test_inventory_weight_and_stats(cli_runner, tmp_path):
@@ -21,7 +21,7 @@ def test_inventory_weight_and_stats(cli_runner, tmp_path):
 
     # Inventory header and weight
     assert yellow("You are carrying the following items: (Total Weight: 45 LB's)") in out
-    assert cyan('Ion-Decay, Ion-Decay, Gold-Chunk.') in out
+    assert white('Ion-Decay, Ion-Decay (1), Gold-Chunk.') in out
 
     # Stats page ions
     assert 'Ions         : 0' in out

--- a/tests/test_travel_cost.py
+++ b/tests/test_travel_cost.py
@@ -8,8 +8,6 @@ from mutants2.engine import persistence
 from mutants2.engine.world import World
 from mutants2.engine.player import Player
 from mutants2.ui.theme import yellow
-from mutants2.engine import rng as rng_mod
-from mutants2.engine.world import ALLOWED_CENTURIES
 
 
 def run(commands: list[str], *, ions: int = 0, start_year: int = 2000, start_pos: tuple[int, int] = (0, 0)):
@@ -39,13 +37,11 @@ def test_travel_costs_when_travelling_backward():
     assert p.year == 2300 and p.ions == 5_000
 
 
-def test_travel_insufficient_ions_mishap():
+def test_travel_insufficient_ions_no_move():
     out, p = run(["travel 2500"], ions=14_000)
-    base_seed = World().global_seed
-    rng = rng_mod.hrand(base_seed, 0, 2000, 2500, "travel_mishap")
-    expected = rng.choice(ALLOWED_CENTURIES)
-    assert yellow("ZAAPPP!!!! You suddenly feel something has gone terribly wrong!") in out
-    assert p.year == expected and p.ions == 0
+    assert yellow("***") in out
+    assert yellow("You don't have enough ions to create a portal.") in out
+    assert p.year == 2000 and p.ions == 14_000
 
 
 def test_same_century_travel_free_and_resets_position():


### PR DESCRIPTION
## Summary
- Enforce inventory limit of 10 items and ground limit of 6 items
- Swap random items on overflows and render inventory line in white with stacking
- Prevent cross-century travel without required ions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb0a70f53c832ba8ba3463d58a75a6