### PR TITLE
Implement sequential item enumeration with ANSI-safe wrapping

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -35,7 +35,12 @@ from ..ui.help import MACROS_HELP, ABBREVIATIONS_NOTE, COMMANDS_HELP, USAGE
 from ..ui.strings import GET_WHAT, DROP_WHAT
 from ..ui.theme import red, SEP, yellow, white
 from ..data.config import ION_TRAVEL_COST, HEAL_K
-from ..ui.render import render_help_hint, render_status
+from ..ui.render import (
+    render_help_hint,
+    render_status,
+    enumerate_duplicates,
+    wrap_ansi,
+)
 from .input import gerundize
 
 
@@ -373,7 +378,7 @@ def make_context(p, w, save, *, dev: bool = False):
         raw = " ".join(args)
         canon = items.canon_item_key(raw)
         key_match = None
-        for k in p.inventory.keys():
+        for k in p.inventory:
             if items.canon_item_key(k).startswith(canon) or items.canon_item_key(
                 items.display_name(k)
             ).startswith(canon):
@@ -508,11 +513,9 @@ def make_context(p, w, save, *, dev: bool = False):
             )
         )
         if p.inventory:
-            names: list[str] = []
-            for key, count in p.inventory.items():
-                names.extend([items.REGISTRY[key].name] * count)
-            line = ", ".join(items.stack_plain(names))
-            lines.append(white(line))
+            names = [items.REGISTRY[key].name for key in p.inventory]
+            line = ", ".join(enumerate_duplicates(names)) + "."
+            lines.extend(wrap_ansi(white(line)).splitlines())
         else:
             lines.append("(empty)")
         for ln in lines:
@@ -559,11 +562,10 @@ def make_context(p, w, save, *, dev: bool = False):
                 )
             )
             if p.inventory:
-                names: list[str] = []
-                for key, count in p.inventory.items():
-                    names.extend([items.REGISTRY[key].name] * count)
-                line = ", ".join(items.stack_plain(names))
-                print(white(line))
+                names = [items.REGISTRY[key].name for key in p.inventory]
+                line = ", ".join(enumerate_duplicates(names)) + "."
+                for ln in wrap_ansi(white(line)).splitlines():
+                    print(ln)
             else:
                 print("(empty)")
         elif cmd == "get":

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -122,9 +122,12 @@ def load() -> tuple[
             player.positions.update(positions)
             player.max_hp = int(data.get("max_hp", player.max_hp))
             player.hp = int(data.get("hp", player.max_hp))
-            player.inventory.update(
-                {k: int(v) for k, v in data.get("inventory", {}).items()}
-            )
+            inv_raw = data.get("inventory", [])
+            if isinstance(inv_raw, dict):
+                for k, v in inv_raw.items():
+                    player.inventory.extend([k] * int(v))
+            else:
+                player.inventory.extend(str(k) for k in inv_raw)
             player.ions = int(data.get("ions", 0))
             player.level = int(data.get("level", 1))
             player.exp = int(data.get("exp", 0))
@@ -251,7 +254,7 @@ def save(player: Player, world: World, save_meta: Save) -> None:
             "max_hp": player.max_hp,
             "level": player.level,
             "exp": player.exp,
-            "inventory": {k: v for k, v in player.inventory.items()},
+            "inventory": list(player.inventory),
             "ions": player.ions,
             "strength": player.strength,
             "intelligence": player.intelligence,

--- a/mutants2/engine/render.py
+++ b/mutants2/engine/render.py
@@ -2,11 +2,12 @@ from .world import World
 from .player import Player
 from .senses import SensesCues
 from ..render import render_room_at
+from ..ui.render import wrap_ansi
 
 
 def shadow_lines(world: World, player: Player) -> list[str]:
     ds = world.shadow_dirs(player.year, player.x, player.y)
-    return [f"You see shadows to the {', '.join(ds)}."] if ds else []
+    return [wrap_ansi(f"You see shadows to the {', '.join(ds)}.")] if ds else []
 
 
 def entry_yell_lines(ctx) -> list[str]:
@@ -18,7 +19,7 @@ def entry_yell_lines(ctx) -> list[str]:
 def arrival_lines(ctx) -> list[str]:
     infos = getattr(ctx, "_arrivals_this_tick", []) or []
     ctx._arrivals_this_tick = []
-    return [f"{name} has just arrived from the {d}." for _, name, d in infos]
+    return [wrap_ansi(f"{name} has just arrived from the {d}.") for _, name, d in infos]
 
 
 def footsteps_lines(ctx) -> list[str]:
@@ -28,9 +29,10 @@ def footsteps_lines(ctx) -> list[str]:
         return []
     kind, d = ev
     if kind == "faint":
-        return [f"You hear faint sounds of footsteps far to the {d}."]
+        msg = f"You hear faint sounds of footsteps far to the {d}."
     else:
-        return [f"You hear loud sounds of footsteps to the {d}."]
+        msg = f"You hear loud sounds of footsteps to the {d}."
+    return [wrap_ansi(msg)]
 
 
 def render_room_view(

--- a/mutants2/engine/state.py
+++ b/mutants2/engine/state.py
@@ -15,7 +15,7 @@ class CharacterProfile:
     positions: Dict[int, Tuple[int, int]] = field(
         default_factory=lambda: {c: (0, 0) for c in ALLOWED_CENTURIES}
     )
-    inventory: Dict[str, int] = field(default_factory=dict)
+    inventory: list[str] = field(default_factory=list)
     hp: int = 10
     max_hp: int = 10
     ions: int = 0
@@ -40,7 +40,7 @@ def profile_from_player(p: "Player") -> CharacterProfile:
     return CharacterProfile(
         year=p.year,
         positions=dict(p.positions),
-        inventory=dict(p.inventory),
+        inventory=list(p.inventory),
         hp=p.hp,
         max_hp=p.max_hp,
         ions=p.ions,
@@ -64,7 +64,7 @@ def apply_profile(p: "Player", prof: CharacterProfile) -> None:
 
     p.year = prof.year
     p.positions = {int(y): (x, y2) for y, (x, y2) in prof.positions.items()}
-    p.inventory = dict(prof.inventory)
+    p.inventory = list(prof.inventory)
     p.hp = prof.hp
     p.max_hp = prof.max_hp
     p.ions = prof.ions
@@ -88,7 +88,7 @@ def profile_to_raw(prof: CharacterProfile) -> dict:
         "positions": {
             str(y): {"x": x, "y": yy} for y, (x, yy) in prof.positions.items()
         },
-        "inventory": {k: v for k, v in prof.inventory.items()},
+        "inventory": list(prof.inventory),
         "hp": prof.hp,
         "max_hp": prof.max_hp,
         "ions": prof.ions,
@@ -109,13 +109,19 @@ def profile_to_raw(prof: CharacterProfile) -> dict:
 
 
 def profile_from_raw(data: dict) -> CharacterProfile:
+    inv_raw = data.get("inventory", [])
+    inventory = (
+        list(inv_raw)
+        if isinstance(inv_raw, list)
+        else [k for k, v in inv_raw.items() for _ in range(int(v))]
+    )
     return CharacterProfile(
         year=int(data.get("year", ALLOWED_CENTURIES[0])),
         positions={
             int(k): (v.get("x", 0), v.get("y", 0))
             for k, v in data.get("positions", {}).items()
         },
-        inventory={k: int(v) for k, v in data.get("inventory", {}).items()},
+        inventory=inventory,
         hp=int(data.get("hp", 10)),
         max_hp=int(data.get("max_hp", 10)),
         ions=int(data.get("ions", 0)),

--- a/mutants2/render.py
+++ b/mutants2/render.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from .ui.theme import red, green, cyan, yellow, white, SEP
-from .engine.items import stack_for_render
+from .ui.render import enumerate_duplicates, wrap_ansi
+from .engine import items as items_mod
 
 
 def _room_desc(world, year, x, y):
@@ -49,11 +50,11 @@ def render_room_at(
             out.append(cyan(f"{d:<5} – area continues."))
 
     # (d/e) ground items followed by a single separator
-    ground_names = [it.name for it in world.items_on_ground(year, x, y)]
+    ground_names = [items_mod.article_name(it.name) for it in world.items_on_ground(year, x, y)]
     if ground_names:
         out.append(yellow("On the ground lies:"))
-        line = ", ".join(stack_for_render(ground_names))
-        out.append(cyan(line))
+        line = ", ".join(enumerate_duplicates(ground_names)) + "."
+        out.extend(wrap_ansi(cyan(line)).splitlines())
     # Always end the header section with one separator
     out.append(SEP)
 
@@ -100,7 +101,7 @@ def render_room_at(
             line = f"{names[0]}, and {names[1]} are here with you."
         else:
             line = f"{', '.join(names[:-1])}, and {names[-1]} are here with you."
-        out.append(white(line))
+        out.extend(wrap_ansi(white(line)).splitlines())
         if shadow_lines or arrivals_for_render:
             out.append(SEP)
 

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -1,4 +1,38 @@
 from .theme import yellow, SEP
+import re
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def enumerate_duplicates(items: list[str]) -> list[str]:
+    """Return ``items`` with duplicate names enumerated sequentially."""
+    seen: dict[str, int] = {}
+    out: list[str] = []
+    for name in items:
+        idx = seen.get(name, 0)
+        out.append(name if idx == 0 else f"{name} ({idx})")
+        seen[name] = idx + 1
+    return out
+
+
+def wrap_ansi(text: str, width: int = 80) -> str:
+    """Wrap ``text`` at ``width`` visible characters, preserving ANSI codes."""
+    tokens = text.split(" ")
+    lengths = [len(ANSI_RE.sub("", tok)) for tok in tokens]
+    lines: list[list[str]] = [[]]
+    cur_len = 0
+    for tok, length in zip(tokens, lengths):
+        add = length if cur_len == 0 else length + 1
+        if cur_len + add > width and lines[-1]:
+            lines.append([tok])
+            cur_len = length
+        else:
+            if cur_len:
+                cur_len += 1 + length
+            else:
+                cur_len = length
+            lines[-1].append(tok)
+    return "\n".join(" ".join(line) for line in lines if line)
 
 
 def render_help_hint() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def cli_runner(tmp_path):
                         ),
                         "hp": data.get("hp", 10),
                         "max_hp": data.get("max_hp", 10),
-                        "inventory": data.get("inventory", {}),
+                        "inventory": data.get("inventory", []),
                         "ions": data.get("ions", 0),
                     }
                 data["last_class"] = "Warrior"
@@ -53,7 +53,7 @@ def cli_runner(tmp_path):
                     "positions": {str(y): {"x": x, "y": yy} for y, (x, yy) in p.positions.items()},
                     "hp": p.hp,
                     "max_hp": p.max_hp,
-                    "inventory": {},
+                    "inventory": [],
                     "ions": p.ions,
                 }
                 persistence.save(p, w, save)

--- a/tests/smoke/test_render_enumeration_and_wrap.py
+++ b/tests/smoke/test_render_enumeration_and_wrap.py
@@ -1,0 +1,58 @@
+import contextlib
+import datetime
+import io
+
+from mutants2.engine import persistence, world as world_mod, items
+from mutants2.engine.player import Player
+from mutants2.cli.shell import make_context
+from mutants2.ui.theme import yellow, white, cyan
+
+
+def _ctx(tmp_path):
+    persistence.SAVE_PATH = tmp_path / 'save.json'
+    w = world_mod.World(seeded_years={2000})
+    p = Player(year=2000, clazz='Warrior')
+    save = persistence.Save()
+    save.last_topup_date = datetime.date.today().isoformat()
+    ctx = make_context(p, w, save, dev=True)
+    return ctx
+
+
+def test_enumeration_and_wrap(tmp_path):
+    ctx = _ctx(tmp_path)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('debug item add cheese 2')
+        ctx.dispatch_line('look')
+    out = buf.getvalue()
+    assert yellow('On the ground lies:') in out
+    assert cyan('A Cheese, A Cheese (1).') in out
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('get cheese')
+        ctx.dispatch_line('get cheese')
+        ctx.dispatch_line('debug item add nuclear_rock')
+        ctx.dispatch_line('get nuclear-rock')
+        ctx.dispatch_line('debug item add cheese')
+        ctx.dispatch_line('get cheese')
+        ctx.dispatch_line('inventory')
+    inv_out = buf.getvalue()
+    assert white('Cheese, Cheese (1), Nuclear-Rock, Cheese (2).') in inv_out
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        for _ in range(5):
+            ctx.dispatch_line('debug item add nuclear_rock')
+            ctx.dispatch_line('get nuclear-rock')
+        for _ in range(5):
+            ctx.dispatch_line('debug item add ion_decay')
+            ctx.dispatch_line('get ion-decay')
+        ctx.dispatch_line('inventory')
+    wrap_out = buf.getvalue()
+    item_lines = [
+        ln for ln in wrap_out.splitlines() if 'Cheese' in ln or 'Nuclear-Rock' in ln or 'Ion-Decay' in ln
+    ]
+    assert len(item_lines) >= 2
+    assert 'Nuclear-\nRock' not in wrap_out

--- a/tests/smoke/test_stats_page.py
+++ b/tests/smoke/test_stats_page.py
@@ -11,7 +11,7 @@ from mutants2.ui.theme import yellow, white
 def test_stats_page(tmp_path):
     persistence.SAVE_PATH = tmp_path / 'save.json'
     p = Player(year=2000, clazz='Warrior')
-    p.inventory.update({'ion_decay': 2, 'gold_chunk': 1})
+    p.inventory.extend(['ion_decay', 'ion_decay', 'gold_chunk'])
     w = world_mod.World(seeded_years={2000})
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()

--- a/tests/smoke/test_travel_convert_and_items.py
+++ b/tests/smoke/test_travel_convert_and_items.py
@@ -15,7 +15,7 @@ def test_monster_bait_conversion(cli_runner, tmp_path):
     persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
     os.environ['HOME'] = str(tmp_path)
     p = Player()
-    p.inventory['monster_bait'] = 1
+    p.inventory.append('monster_bait')
     w = World(seeded_years={2000})
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,7 +24,7 @@ def _ensure_profile(tmp_path):
                 "positions": data.get("positions", {str(2000): {"x": 0, "y": 0}}),
                 "hp": data.get("hp", 10),
                 "max_hp": data.get("max_hp", 10),
-                "inventory": data.get("inventory", {}),
+                "inventory": data.get("inventory", []),
                 "ions": data.get("ions", 0),
             }
         data["last_class"] = "Warrior"
@@ -41,7 +41,7 @@ def _ensure_profile(tmp_path):
             "positions": {str(y): {"x": x, "y": yy} for y, (x, yy) in p.positions.items()},
             "hp": p.hp,
             "max_hp": p.max_hp,
-            "inventory": {},
+            "inventory": [],
             "ions": p.ions,
         }
         persistence.save(p, w, save)

--- a/tests/test_convert_command.py
+++ b/tests/test_convert_command.py
@@ -14,7 +14,7 @@ def inventory_with_cap(tmp_path):
     persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
     os.environ['HOME'] = str(tmp_path)
     p = Player()
-    p.inventory['bottle_cap'] = 1
+    p.inventory.append('bottle_cap')
     w = World(seeded_years={2000})
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()

--- a/tests/test_item_limits.py
+++ b/tests/test_item_limits.py
@@ -36,12 +36,12 @@ def test_inventory_limit_swap():
     ]
     p = Player()
     for k in inv_keys:
-        p.inventory[k] = 1
+        p.inventory.append(k)
     w = World({(2000, 0, 0): ["bottle_cap"]}, {2000}, global_seed=123)
 
     out = run(["get Bottle-Cap"], p=p, w=w)
 
-    assert sum(p.inventory.values()) == INVENTORY_LIMIT
+    assert len(p.inventory) == INVENTORY_LIMIT
     ground_items = w.items_on_ground(2000, 0, 0)
     assert len(ground_items) == 1
     victim_name = ground_items[0].name
@@ -63,13 +63,13 @@ def test_ground_limit_swap():
     ]
     w = World({(2000, 0, 0): ground_keys}, {2000}, global_seed=123)
     p = Player()
-    p.inventory["cigarette_butt"] = 1
+    p.inventory.append("cigarette_butt")
 
     out = run(["drop Cigarette-Butt"], p=p, w=w)
 
     assert len(w.items_on_ground(2000, 0, 0)) == 6
-    assert sum(p.inventory.values()) == 1
-    gift_key = next(iter(p.inventory.keys()))
+    assert len(p.inventory) == 1
+    gift_key = p.inventory[0]
     gift_name = items.REGISTRY[gift_key].name
     assert yellow("***") in out
     assert yellow(f"{items.article_name(gift_name)} has magically appeared in your hand!") in out

--- a/tests/test_item_schema.py
+++ b/tests/test_item_schema.py
@@ -31,6 +31,6 @@ def test_catalog_has_correct_values(name, expected):
 
 def test_inventory_weight_totals():
     p = Player()
-    p.inventory.update({"ion_decay": 2, "gold_chunk": 1})
+    p.inventory.extend(["ion_decay", "ion_decay", "gold_chunk"])
     # weights: ion_decay=10*2=20, gold_chunk=25 -> total 45
     assert p.inventory_weight_lbs() == 45

--- a/tests/test_items_basic.py
+++ b/tests/test_items_basic.py
@@ -30,7 +30,7 @@ def _ensure_profile(tmp_path):
                 "positions": data.get("positions", {str(2000): {"x": 0, "y": 0}}),
                 "hp": data.get("hp", 10),
                 "max_hp": data.get("max_hp", 10),
-                "inventory": data.get("inventory", {}),
+                "inventory": data.get("inventory", []),
                 "ions": data.get("ions", 0),
             }
         data["last_class"] = "Warrior"
@@ -47,7 +47,7 @@ def _ensure_profile(tmp_path):
             "positions": {str(y): {"x": x, "y": yy} for y, (x, yy) in p.positions.items()},
             "hp": p.hp,
             "max_hp": p.max_hp,
-            "inventory": {},
+            "inventory": [],
             "ions": 0,
         }
         persistence.save(p, w, save)
@@ -93,7 +93,7 @@ def test_inventory_rendering(tmp_path):
     persistence.SAVE_PATH = Path(tmp_path) / '.mutants2' / 'save.json'
     os.environ['HOME'] = str(tmp_path)
     p = Player()
-    p.inventory.update({'ion_decay': 2, 'gold_chunk': 1})
+    p.inventory.extend(['ion_decay', 'ion_decay', 'gold_chunk'])
     w = World(seeded_years={2000})
     save = persistence.Save()
     persistence.save(p, w, save)

--- a/tests/test_items_prefix_and_abbrev.py
+++ b/tests/test_items_prefix_and_abbrev.py
@@ -25,7 +25,7 @@ def inventory_with_item(tmp_path):
     persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
     os.environ['HOME'] = str(tmp_path)
     p = Player()
-    p.inventory['nuclear_thong'] = 1
+    p.inventory.append('nuclear_thong')
     w = World(seeded_years={2000})
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()
@@ -38,7 +38,7 @@ def inventory_with_ion_items(tmp_path):
     persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
     os.environ['HOME'] = str(tmp_path)
     p = Player()
-    p.inventory.update({'ion_decay': 1, 'ion_pack': 1})
+    p.inventory.extend(['ion_decay', 'ion_pack'])
     w = World(seeded_years={2000})
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()

--- a/tests/test_monsters_basic.py
+++ b/tests/test_monsters_basic.py
@@ -78,7 +78,7 @@ def cli_runner_dev(tmp_path):
                         ),
                         "hp": data.get("hp", 10),
                         "max_hp": data.get("max_hp", 10),
-                        "inventory": data.get("inventory", {}),
+                        "inventory": data.get("inventory", []),
                         "ions": data.get("ions", 0),
                     }
                 data["last_class"] = "Warrior"
@@ -95,7 +95,7 @@ def cli_runner_dev(tmp_path):
                     "positions": {str(y): {"x": x, "y": yy} for y, (x, yy) in p.positions.items()},
                     "hp": p.hp,
                     "max_hp": p.max_hp,
-                    "inventory": {},
+                    "inventory": [],
                     "ions": 0,
                 }
                 persistence.save(p, w, save)

--- a/tests/test_player_ions_inventory_weight.py
+++ b/tests/test_player_ions_inventory_weight.py
@@ -12,7 +12,7 @@ def test_inventory_weight_and_stats(cli_runner, tmp_path):
     os.environ['HOME'] = str(tmp_path)
 
     p = Player()
-    p.inventory.update({'ion_decay': 2, 'gold_chunk': 1})
+    p.inventory.extend(['ion_decay', 'ion_decay', 'gold_chunk'])
     w = World(seeded_years={2000})
     save = persistence.Save()
     persistence.save(p, w, save)

--- a/tests/test_prefix_rules.py
+++ b/tests/test_prefix_rules.py
@@ -51,7 +51,7 @@ def world_with_items(world):
 @pytest.fixture
 def world_with_monster_and_item_N_on_tile(world, player):
     world.place_monster(2000, 0, 0, "night_stalker")
-    player.inventory["nuclear_thong"] = 1
+    player.inventory.append("nuclear_thong")
     return world
 
 

--- a/tests/test_progression_tables.py
+++ b/tests/test_progression_tables.py
@@ -69,7 +69,7 @@ def test_migration_recomputes_stats(tmp_path, monkeypatch):
             "warrior": {
                 "year": 2000,
                 "positions": {"2000": {"x": 0, "y": 0}},
-                "inventory": {},
+                "inventory": [],
                 "hp": 9999,
                 "max_hp": 9999,
                 "ions": 0,


### PR DESCRIPTION
## Summary
- Track inventory as ordered list and enumerate duplicates sequentially
- Wrap rendered item lists at 80 columns with ANSI-safe logic
- Add smoke test covering enumeration order and wrapping behavior

## Testing
- `pytest` *(fails: 44 errors during collection)*
- `pytest tests/smoke/test_render_enumeration_and_wrap.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb12bd5374832b98d0c5e761fbce6d