### PR TITLE
Add riblets currency and monster loot transfer

### DIFF
--- a/mutants2/engine/combat.py
+++ b/mutants2/engine/combat.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from ..ui.theme import yellow
 from .leveling import check_level_up
 
 MONSTER_XP = 20_000
 
 
-def award_kill(player) -> None:
-    """Award XP for a monster kill and trigger level-up checks."""
+def award_kill(player) -> int:
+    """Award XP for a monster kill and trigger level-up checks.
+
+    Returns the amount of experience awarded.
+    """
 
     player.exp += MONSTER_XP
-    print(yellow("***"))
-    print(yellow("You gain 20,000 experience points!"))
     check_level_up(player)
+    return MONSTER_XP

--- a/mutants2/engine/monsters.py
+++ b/mutants2/engine/monsters.py
@@ -61,6 +61,8 @@ def spawn(key: str, mid: int) -> dict:
         "has_yelled_this_aggro": False,
         "id": mid,
         "hp": REGISTRY[key].base_hp,
+        "loot_ions": 0,
+        "loot_riblets": 0,
     }
 
 

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -129,6 +129,7 @@ def load() -> tuple[
             else:
                 player.inventory.extend(str(k) for k in inv_raw)
             player.ions = int(data.get("ions", 0))
+            player.riblets = int(data.get("riblets", 0))
             player.level = int(data.get("level", 1))
             player.exp = int(data.get("exp", 0))
             player.strength = int(data.get("strength", 0))
@@ -183,6 +184,8 @@ def load() -> tuple[
                 seen = entry.get("seen", False)
                 has_yelled = entry.get("has_yelled_this_aggro", False)
                 mid = entry.get("id")
+                loot_i = entry.get("loot_ions", 0)
+                loot_r = entry.get("loot_riblets", 0)
                 base = monsters_mod.REGISTRY[m_key].base_hp
                 m: dict[str, object] = {
                     "key": m_key,
@@ -191,6 +194,8 @@ def load() -> tuple[
                     "aggro": bool(aggro),
                     "seen": bool(seen),
                     "has_yelled_this_aggro": bool(has_yelled),
+                    "loot_ions": int(loot_i),
+                    "loot_riblets": int(loot_r),
                 }
                 if mid is not None:
                     m["id"] = int(mid)
@@ -256,6 +261,7 @@ def save(player: Player, world: World, save_meta: Save) -> None:
             "exp": player.exp,
             "inventory": list(player.inventory),
             "ions": player.ions,
+            "riblets": getattr(player, "riblets", 0),
             "strength": player.strength,
             "intelligence": player.intelligence,
             "wisdom": player.wisdom,
@@ -291,6 +297,8 @@ def save(player: Player, world: World, save_meta: Save) -> None:
                                 "has_yelled_this_aggro", False
                             ),
                             "id": m.get("id"),
+                            "loot_ions": m.get("loot_ions", 0),
+                            "loot_riblets": m.get("loot_riblets", 0),
                         }
                         for m in lst
                     ]

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -43,6 +43,7 @@ class Player:
     hp: int = 10
     max_hp: int = 10
     ions: int = 0
+    riblets: int = 0
     level: int = 1
     exp: int = 0
     strength: int = 0

--- a/mutants2/engine/state.py
+++ b/mutants2/engine/state.py
@@ -19,6 +19,7 @@ class CharacterProfile:
     hp: int = 10
     max_hp: int = 10
     ions: int = 0
+    riblets: int = 0
     level: int = 1
     exp: int = 0
     strength: int = 0
@@ -44,6 +45,7 @@ def profile_from_player(p: "Player") -> CharacterProfile:
         hp=p.hp,
         max_hp=p.max_hp,
         ions=p.ions,
+        riblets=getattr(p, "riblets", 0),
         level=getattr(p, "level", 1),
         exp=getattr(p, "exp", 0),
         strength=getattr(p, "strength", 0),
@@ -68,6 +70,7 @@ def apply_profile(p: "Player", prof: CharacterProfile) -> None:
     p.hp = prof.hp
     p.max_hp = prof.max_hp
     p.ions = prof.ions
+    p.riblets = getattr(prof, "riblets", 0)
     p.level = getattr(prof, "level", 1)
     p.exp = getattr(prof, "exp", 0)
     p.strength = getattr(prof, "strength", 0)
@@ -92,6 +95,7 @@ def profile_to_raw(prof: CharacterProfile) -> dict:
         "hp": prof.hp,
         "max_hp": prof.max_hp,
         "ions": prof.ions,
+        "riblets": getattr(prof, "riblets", 0),
         "level": getattr(prof, "level", 1),
         "exp": getattr(prof, "exp", 0),
         "strength": getattr(prof, "strength", 0),
@@ -125,6 +129,7 @@ def profile_from_raw(data: dict) -> CharacterProfile:
         hp=int(data.get("hp", 10)),
         max_hp=int(data.get("max_hp", 10)),
         ions=int(data.get("ions", 0)),
+        riblets=int(data.get("riblets", 0)),
         level=int(data.get("level", 1)),
         exp=int(data.get("exp", 0)),
         strength=int(data.get("strength", 0)),

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -167,6 +167,8 @@ class World:
                     has_yelled = entry.get("has_yelled_this_aggro", False)
                     mid_val = entry.get("id")
                     mid = int(cast(int, mid_val)) if mid_val is not None else None
+                    loot_i = entry.get("loot_ions", 0)
+                    loot_r = entry.get("loot_riblets", 0)
                     base = monsters_mod.REGISTRY[m_key].base_hp
                     if mid is None:
                         mid = self._id_alloc.allocate()
@@ -181,6 +183,8 @@ class World:
                         "seen": bool(seen),
                         "has_yelled_this_aggro": bool(has_yelled),
                         "id": int(mid),
+                        "loot_ions": int(loot_i),
+                        "loot_riblets": int(loot_r),
                     }
                     if m.get("aggro") and not m.get("seen"):
                         m["aggro"] = False

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -1,4 +1,4 @@
-from .theme import yellow, SEP
+from .theme import yellow, red, SEP
 import re
 
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
@@ -62,7 +62,7 @@ def render_status(p) -> list[str]:
         ),
         yellow(f"Hit Points   : {p.hp} / {p.max_hp}"),
         yellow(f"Exp. Points  : {p.exp}           Level: {p.level}"),
-        yellow("Riblets      : 0"),
+        yellow(f"Riblets      : {getattr(p, 'riblets', 0)}"),
         yellow(f"Ions         : {p.ions}"),
         yellow(f"Wearing Armor: Nothing.  Armour Class: {p.ac_total}"),
         yellow("Ready to Combat: NO ONE"),
@@ -71,3 +71,21 @@ def render_status(p) -> list[str]:
         "",
     ]
     return lines
+
+
+def render_kill_block(name: str, xp: int, riblets: int, ions: int) -> None:
+    """Render the red kill message block for monster deaths."""
+
+    print(red(f"You have slain {name}!"))
+    print()
+    print(red(f"Your experience points are increased by {xp:,}!"))
+    print()
+    print(
+        red(
+            f"You collect {riblets:,} Riblets and {ions:,} ions from the slain body."
+        )
+    )
+    print()
+    print(red("***"))
+    print()
+    print(red(f"{name} is crumbling to dust!"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,7 @@ def cli_runner(tmp_path):
                         "max_hp": data.get("max_hp", 10),
                         "inventory": data.get("inventory", []),
                         "ions": data.get("ions", 0),
+                        "riblets": data.get("riblets", 0),
                     }
                 data["last_class"] = "Warrior"
                 with open(save_path, "w") as fh:
@@ -55,6 +56,7 @@ def cli_runner(tmp_path):
                     "max_hp": p.max_hp,
                     "inventory": [],
                     "ions": p.ions,
+                    "riblets": p.riblets,
                 }
                 persistence.save(p, w, save)
             inp = "\n".join(commands + ["exit"]) + "\n"

--- a/tests/smoke/test_errant_and_attack_rendering.py
+++ b/tests/smoke/test_errant_and_attack_rendering.py
@@ -38,7 +38,7 @@ def test_attack_no_room_block_but_arrival():
     out, w, _p, _ = run_commands(["attack"], setup=setup)
     assert "You are here." not in out
     assert "Compass:" not in out
-    assert re.search(r"You defeat the Mutant-\d{4}\.", out)
+    assert re.search(r"You have slain Mutant-\d{4}!", out)
     assert "has just arrived from the east." in out
 
 

--- a/tests/test_combat_minimal.py
+++ b/tests/test_combat_minimal.py
@@ -35,7 +35,7 @@ def empty_start_world(tmp_path):
 
 def test_attack_kills_with_few_hits(world_with_mutant_on_start, cli_runner):
     out = cli_runner.run_commands(["att", "att"])
-    assert re.search(r"You defeat the Mutant-\d{4}", out)
+    assert re.search(r"You have slain Mutant-\d{4}!", out)
 
 
 def test_retaliation_and_death_respawn(world_with_mutant_on_start, cli_runner):

--- a/tests/test_debug_riblets.py
+++ b/tests/test_debug_riblets.py
@@ -1,0 +1,31 @@
+import contextlib
+import io
+import re
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def test_debug_set_riblets(tmp_path):
+    persistence.SAVE_PATH = tmp_path / 'save.json'
+    w = world_mod.World(global_seed=42)
+    w.year(2000)
+    p = Player(year=2000, clazz='Warrior')
+    save = persistence.Save()
+    ctx = make_context(p, w, save, dev=True)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('debug set riblet 4242')
+    out = strip_ansi(buf.getvalue())
+    assert 'Riblets set to 4242.' in out
+    assert p.riblets == 4242
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('help debug')
+    out = buf.getvalue()
+    assert 'debug set riblet <N>' in out

--- a/tests/test_inventory_render_only.py
+++ b/tests/test_inventory_render_only.py
@@ -1,0 +1,24 @@
+import contextlib
+import io
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+
+
+def test_inventory_render_only(tmp_path):
+    persistence.SAVE_PATH = tmp_path / 'save.json'
+    w = world_mod.World(seeded_years={2000})
+    p = Player(year=2000, clazz='Warrior')
+    p.inventory.append('ion_decay')
+    save = persistence.Save()
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('inventory')
+    out = buf.getvalue()
+    lines = [ln for ln in out.splitlines() if ln.strip()]
+    assert 'You are carrying the following items:' in lines[1]
+    assert 'Ion-Decay' in lines[2]
+    assert all('Compass' not in ln for ln in lines)
+    assert w.turn == 0

--- a/tests/test_monster_loot.py
+++ b/tests/test_monster_loot.py
@@ -1,0 +1,55 @@
+import contextlib
+import io
+import re
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def test_kill_loot_award(tmp_path):
+    persistence.SAVE_PATH = tmp_path / 'save.json'
+    w = world_mod.World(
+        monsters={(2000, 0, 0): [{"key": "mutant", "hp": 3, "loot_ions": 5, "loot_riblets": 7}]},
+        seeded_years={2000},
+    )
+    p = Player(year=2000, clazz='Warrior')
+    save = persistence.Save()
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('attack')
+        ctx.dispatch_line('attack')
+    out = strip_ansi(buf.getvalue())
+    assert 'You have slain Mutant-' in out
+    assert 'Your experience points are increased by 20,000!' in out
+    assert 'You collect 20,007 Riblets and 20,005 ions' in out
+    assert p.ions == 20005
+    assert p.riblets == 20007
+
+
+def test_death_transfer_and_reward(tmp_path):
+    persistence.SAVE_PATH = tmp_path / 'save.json'
+    w = world_mod.World(
+        monsters={(2000, 0, 0): [{"key": "leucrotta", "hp": 3}]}, seeded_years={2000}
+    )
+    p = Player(year=2000, clazz='Warrior', hp=1, max_hp=1, ions=12345, riblets=67890)
+    save = persistence.Save()
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('attack')
+    m = w.monster_here(2000, 0, 0)
+    assert p.ions == 0
+    assert p.riblets == 0
+    assert int(m.get('loot_ions')) == 12345
+    assert int(m.get('loot_riblets')) == 67890
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('attack')
+    assert p.ions == 20000 + 12345
+    assert p.riblets == 20000 + 67890


### PR DESCRIPTION
## Summary
- make `inventory` command render-only without advancing turns
- track riblets and ion loot on monsters and transfer on player death
- show red kill message awarding 20k riblets/ions plus stored loot
- add `debug set riblet(s)` command and persist riblets

## Testing
- `pytest >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_68bb19786224832b9ee68f00e163f52a