### PR TITLE
feat: add monster skull loot

### DIFF
--- a/mutants2/engine/types.py
+++ b/mutants2/engine/types.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
-from typing import Mapping, MutableMapping, Sequence, Tuple, Literal
+from typing import Mapping, MutableMapping, Sequence, Tuple, Literal, TYPE_CHECKING, Union
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .state import ItemInstance
 
 TileKey = Tuple[int, int, int]
 Direction = Literal["north", "south", "east", "west"]
-ItemList = Sequence[str]
-ItemListMut = list[str]
+ItemList = Sequence[Union[str, "ItemInstance"]]
+ItemListMut = list[Union[str, "ItemInstance"]]
 MonsterRec = Mapping[str, object]
 MonsterList = Sequence[MonsterRec]
 

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -75,17 +75,7 @@ def render_status(p) -> list[str]:
 
 def render_kill_block(name: str, xp: int, riblets: int, ions: int) -> None:
     """Render the red kill message block for monster deaths."""
-
     print(red(f"You have slain {name}!"))
-    print()
-    print(red(f"Your experience points are increased by {xp:,}!"))
-    print()
-    print(
-        red(
-            f"You collect {riblets:,} Riblets and {ions:,} ions from the slain body."
-        )
-    )
-    print()
-    print(red("***"))
-    print()
-    print(red(f"{name} is crumbling to dust!"))
+    print(red(f"Your experience points are increased by {xp}!"))
+    print(red(f"You collect {riblets} Riblets and {ions} ions from the slain body."))
+    print("***")

--- a/tests/test_monster_loot.py
+++ b/tests/test_monster_loot.py
@@ -26,10 +26,40 @@ def test_kill_loot_award(tmp_path):
         ctx.dispatch_line('attack')
     out = strip_ansi(buf.getvalue())
     assert 'You have slain Mutant-' in out
-    assert 'Your experience points are increased by 20,000!' in out
-    assert 'You collect 20,007 Riblets and 20,005 ions' in out
+    assert 'Your experience points are increased by 20000!' in out
+    assert 'You collect 20007 Riblets and 20005 ions' in out
+    assert 'A Skull is falling from Mutant-' in out
+    assert 'is crumbling to dust!' in out
     assert p.ions == 20005
     assert p.riblets == 20007
+
+
+def test_kill_numbers_no_commas(tmp_path):
+    persistence.SAVE_PATH = tmp_path / 'save.json'
+    w = world_mod.World(
+        monsters={
+            (2000, 0, 0): [
+                {
+                    "key": "mutant",
+                    "hp": 3,
+                    "loot_ions": 29821,
+                    "loot_riblets": -6520,
+                }
+            ]
+        },
+        seeded_years={2000},
+    )
+    p = Player(year=2000, clazz='Warrior')
+    save = persistence.Save()
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('attack')
+        ctx.dispatch_line('attack')
+    out = strip_ansi(buf.getvalue())
+    assert 'You collect 13480 Riblets and 49821 ions' in out
+    assert '13,480' not in out
+    assert '49,821' not in out
 
 
 def test_death_transfer_and_reward(tmp_path):

--- a/tests/test_skull_item.py
+++ b/tests/test_skull_item.py
@@ -1,0 +1,37 @@
+import contextlib
+import io
+import re
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+from mutants2.engine.state import ItemInstance
+
+
+def strip_ansi(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def test_skull_look_and_convert(tmp_path):
+    persistence.SAVE_PATH = tmp_path / 'save.json'
+    w = world_mod.World(seeded_years={2000})
+    p = Player(year=2000, clazz='Warrior')
+    p.inventory.append(ItemInstance('skull', {'monster_type': 'Crio-Sphinx'}))
+    save = persistence.Save()
+    ctx = make_context(p, w, save)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('look skull')
+    out = strip_ansi(buf.getvalue())
+    assert 'of a Crio-Sphinx!' in out
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line('convert skull')
+        ctx.dispatch_line('inventory')
+        ctx.dispatch_line('status')
+    out = strip_ansi(buf.getvalue())
+    assert 'You convert the Skull into 25,000 ions.' in out
+    assert '(empty)' in out
+    assert 'Ions         : 25000' in out


### PR DESCRIPTION
## Summary
- show kill rewards without commas and drop monster skulls before crumbling
- add Skull item with custom description and conversion value
- support ItemInstance metadata and handle skull look/convert

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb2378d0d0832baf7c538dba4b6a92