### PR TITLE
Robust ANSI wrapping and non-breaking item counts

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -16,13 +16,17 @@ from ..engine.loop import (
 )
 from ..engine.leveling import recompute_from_exp
 from ..engine.player import (
-    CLASS_DISPLAY,
     CLASS_LIST,
     CLASS_BY_NUM,
     CLASS_BY_NAME,
     class_key,
 )
-from ..engine.state import CharacterProfile, apply_profile, profile_from_raw, ItemInstance
+from ..engine.state import (
+    CharacterProfile,
+    apply_profile,
+    profile_from_raw,
+    ItemInstance,
+)
 from ..engine.gen import (
     daily_topup_if_needed,
     debug_item_topup,
@@ -39,9 +43,9 @@ from ..ui.render import (
     render_help_hint,
     render_status,
     enumerate_duplicates,
-    wrap_ansi,
     render_kill_block,
 )
+from ..ui.wrap import wrap_list_ansi
 from .input import gerundize
 
 
@@ -329,7 +333,9 @@ def make_context(p, w, save, *, dev: bool = False):
             else:
                 p.ions -= cost
                 p.travel(w, target)
-                print(yellow(f"ZAAAAPPPPP!! You've been sent to the year {target} A.D."))
+                print(
+                    yellow(f"ZAAAAPPPPP!! You've been sent to the year {target} A.D.")
+                )
         context._suppress_room_render = True
         context._suppress_entry_aggro = True
         context._skip_movement_tick = False
@@ -368,7 +374,11 @@ def make_context(p, w, save, *, dev: bool = False):
             print(yellow(f"The {sack_name} fell out of your sack!"))
         if gift_name:
             print(yellow("***"))
-            print(yellow(f"{items.article_name(gift_name)} has magically appeared in your hand!"))
+            print(
+                yellow(
+                    f"{items.article_name(gift_name)} has magically appeared in your hand!"
+                )
+            )
         return False
 
     def handle_convert(args: list[str]) -> bool:
@@ -552,13 +562,12 @@ def make_context(p, w, save, *, dev: bool = False):
         )
         if p.inventory:
             names = [
-                items.REGISTRY[
-                    obj.key if isinstance(obj, ItemInstance) else obj
-                ].name
+                items.REGISTRY[obj.key if isinstance(obj, ItemInstance) else obj].name
                 for obj in p.inventory
             ]
-            line = ", ".join(enumerate_duplicates(names)) + "."
-            lines.extend(wrap_ansi(white(line)).splitlines())
+            labels = enumerate_duplicates(names)
+            wrapped = wrap_list_ansi(labels)
+            lines.extend(white(ln) for ln in wrapped.splitlines())
         else:
             lines.append("(empty)")
         for ln in lines:
@@ -611,9 +620,10 @@ def make_context(p, w, save, *, dev: bool = False):
                     ].name
                     for obj in p.inventory
                 ]
-                line = ", ".join(enumerate_duplicates(names)) + "."
-                for ln in wrap_ansi(white(line)).splitlines():
-                    print(ln)
+                labels = enumerate_duplicates(names)
+                wrapped = wrap_list_ansi(labels)
+                for ln in wrapped.splitlines():
+                    print(white(ln))
             else:
                 print("(empty)")
             context._needs_render = False
@@ -800,7 +810,8 @@ def make_context(p, w, save, *, dev: bool = False):
                         p.ions = val
                         print(yellow(f"Ions set to {val}."))
                 elif (
-                    args[:2] in (["set", "riblet"], ["set", "riblets"]) and len(args) >= 3
+                    args[:2] in (["set", "riblet"], ["set", "riblets"])
+                    and len(args) >= 3
                 ):
                     try:
                         val = max(0, int(args[2]))

--- a/mutants2/engine/items.py
+++ b/mutants2/engine/items.py
@@ -1,11 +1,13 @@
 from dataclasses import dataclass
 import re
-from typing import Optional, Callable, Any
+from typing import Optional, Callable
 import collections
 
 from .state import ItemInstance
 from ..ui.theme import yellow
-from ..ui.render import wrap_ansi
+from ..ui.wrap import wrap_paragraph_ansi
+
+NBSP = "\u00a0"
 
 
 @dataclass(frozen=True)
@@ -54,13 +56,13 @@ _add("bottle_cap", "Bottle-Cap", 1, 22000, 606, spawnable=True)
 
 
 def describe_skull(inst: ItemInstance) -> str:
-    mt = inst.meta.get("monster_type", "Unknown")
+    monster_type = inst.meta.get("monster_type", "Unknown")
     text = (
-        "A shiver is sent down your spine as you realize this is the skull\n"
-        "of a victim that has lost in a bloody battle. Looking closer, you realize\n"
-        f"this is the skull of a {mt}!"
+        "A shiver is sent down your spine as you realize this is the skull "
+        "of a victim that has lost in a bloody battle. Looking closer, you realize "
+        f"this is the skull of a {monster_type}!"
     )
-    return yellow(wrap_ansi(text))
+    return yellow(wrap_paragraph_ansi(text, 80))
 
 
 _add(
@@ -179,7 +181,7 @@ def stack_for_render(item_names: list[str]) -> list[str]:
             tokens.append(article_name(name))
         else:
             tokens.append(article_name(name))
-            tokens.append(f"{article_name(name)} ({counts[name]-1})")
+            tokens.append(f"{article_name(name)}{NBSP}({counts[name]-1})")
         counts[name] = 0
     if tokens:
         tokens[-1] = tokens[-1] + "."
@@ -196,7 +198,7 @@ def stack_plain(item_names: list[str]) -> list[str]:
             tokens.append(name)
         else:
             tokens.append(name)
-            tokens.append(f"{name} ({counts[name]-1})")
+            tokens.append(f"{name}{NBSP}({counts[name]-1})")
         counts[name] = 0
     if tokens:
         tokens[-1] = tokens[-1] + "."

--- a/mutants2/render.py
+++ b/mutants2/render.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from .ui.theme import red, green, cyan, yellow, white, SEP
 from .ui.render import enumerate_duplicates, wrap_ansi
+from .ui.wrap import wrap_list_ansi
 from .engine import items as items_mod
 
 
@@ -50,11 +51,14 @@ def render_room_at(
             out.append(cyan(f"{d:<5} – area continues."))
 
     # (d/e) ground items followed by a single separator
-    ground_names = [items_mod.article_name(it.name) for it in world.items_on_ground(year, x, y)]
+    ground_names = [
+        items_mod.article_name(it.name) for it in world.items_on_ground(year, x, y)
+    ]
     if ground_names:
         out.append(yellow("On the ground lies:"))
-        line = ", ".join(enumerate_duplicates(ground_names)) + "."
-        out.extend(wrap_ansi(cyan(line)).splitlines())
+        items = enumerate_duplicates(ground_names)
+        wrapped = wrap_list_ansi(items)
+        out.extend(cyan(ln) for ln in wrapped.splitlines())
     # Always end the header section with one separator
     out.append(SEP)
 

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -1,6 +1,8 @@
 from .theme import yellow, red, SEP
 import re
 
+NBSP = "\u00a0"  # non-breaking space
+
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
@@ -10,7 +12,7 @@ def enumerate_duplicates(items: list[str]) -> list[str]:
     out: list[str] = []
     for name in items:
         idx = seen.get(name, 0)
-        out.append(name if idx == 0 else f"{name} ({idx})")
+        out.append(name if idx == 0 else f"{name}{NBSP}({idx})")
         seen[name] = idx + 1
     return out
 
@@ -54,9 +56,7 @@ def render_status(p) -> list[str]:
     lines = [
         yellow(f"Name: Vindeiatrix / Mutant {disp}"),
         yellow("Exhaustion   : 0"),
-        yellow(
-            f"Str: {p.strength:<2}   Int: {p.intelligence:<2}   Wis: {p.wisdom:<2}"
-        ),
+        yellow(f"Str: {p.strength:<2}   Int: {p.intelligence:<2}   Wis: {p.wisdom:<2}"),
         yellow(
             f"Dex: {p.dexterity:<2}   Con: {p.constitution:<2}   Cha: {p.charisma:<2}"
         ),

--- a/mutants2/ui/wrap.py
+++ b/mutants2/ui/wrap.py
@@ -1,0 +1,61 @@
+import re
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def visible_len(s: str) -> int:
+    return len(ANSI.sub("", s))
+
+
+def wrap_paragraph_ansi(text: str, width: int = 80) -> str:
+    """
+    Wrap a paragraph to 'width' visible columns:
+    - no breaking words
+    - no breaking on hyphens (treat hyphenated compounds as whole words)
+    - preserves ANSI color codes
+    """
+    # Remove any hard line breaks coming in
+    text = " ".join(text.split())
+
+    # Tokenize on spaces but keep ANSI codes embedded in tokens.
+    raw_tokens = text.split(" ")
+
+    lines, cur = [], ""
+    for tok in raw_tokens:
+        # never split tokens; compute length if we were to add this token
+        candidate = tok if not cur else f"{cur} {tok}"
+        if visible_len(candidate) <= width:
+            cur = candidate
+        else:
+            if cur:
+                lines.append(cur)
+            # if a single token is wider than width, place it alone (no hard splitting)
+            cur = tok
+    if cur:
+        lines.append(cur)
+    return "\n".join(lines)
+
+
+def wrap_list_ansi(
+    items: list[str], width: int = 80, trailing_period: bool = True
+) -> str:
+    """
+    Wrap a comma-separated list where each item is an unbreakable token
+    (e.g., 'Cheese\u00a0(1)'); commas attach to the preceding token.
+    """
+    sep = " "
+    lines, cur = [], ""
+    for i, it in enumerate(items):
+        token = it + ("," if i < len(items) - 1 else "")
+        candidate = token if not cur else f"{cur}{sep}{token}"
+        if visible_len(candidate) <= width:
+            cur = candidate
+        else:
+            if cur:
+                lines.append(cur)
+            cur = token
+    if cur:
+        if trailing_period and not cur.endswith("."):
+            cur = cur + "."
+        lines.append(cur)
+    return "\n".join(lines)

--- a/tests/smoke/test_render_enumeration_and_wrap.py
+++ b/tests/smoke/test_render_enumeration_and_wrap.py
@@ -2,16 +2,16 @@ import contextlib
 import datetime
 import io
 
-from mutants2.engine import persistence, world as world_mod, items
+from mutants2.engine import persistence, world as world_mod
 from mutants2.engine.player import Player
 from mutants2.cli.shell import make_context
 from mutants2.ui.theme import yellow, white, cyan
 
 
 def _ctx(tmp_path):
-    persistence.SAVE_PATH = tmp_path / 'save.json'
+    persistence.SAVE_PATH = tmp_path / "save.json"
     w = world_mod.World(seeded_years={2000})
-    p = Player(year=2000, clazz='Warrior')
+    p = Player(year=2000, clazz="Warrior")
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()
     ctx = make_context(p, w, save, dev=True)
@@ -23,36 +23,38 @@ def test_enumeration_and_wrap(tmp_path):
 
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
-        ctx.dispatch_line('debug item add cheese 2')
-        ctx.dispatch_line('look')
+        ctx.dispatch_line("debug item add cheese 2")
+        ctx.dispatch_line("look")
     out = buf.getvalue()
-    assert yellow('On the ground lies:') in out
-    assert cyan('A Cheese, A Cheese (1).') in out
+    assert yellow("On the ground lies:") in out
+    assert cyan("A Cheese, A Cheese\u00a0(1).") in out
 
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
-        ctx.dispatch_line('get cheese')
-        ctx.dispatch_line('get cheese')
-        ctx.dispatch_line('debug item add nuclear_rock')
-        ctx.dispatch_line('get nuclear-rock')
-        ctx.dispatch_line('debug item add cheese')
-        ctx.dispatch_line('get cheese')
-        ctx.dispatch_line('inventory')
+        ctx.dispatch_line("get cheese")
+        ctx.dispatch_line("get cheese")
+        ctx.dispatch_line("debug item add nuclear_rock")
+        ctx.dispatch_line("get nuclear-rock")
+        ctx.dispatch_line("debug item add cheese")
+        ctx.dispatch_line("get cheese")
+        ctx.dispatch_line("inventory")
     inv_out = buf.getvalue()
-    assert white('Cheese, Cheese (1), Nuclear-Rock, Cheese (2).') in inv_out
+    assert white("Cheese, Cheese\u00a0(1), Nuclear-Rock, Cheese\u00a0(2).") in inv_out
 
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         for _ in range(5):
-            ctx.dispatch_line('debug item add nuclear_rock')
-            ctx.dispatch_line('get nuclear-rock')
+            ctx.dispatch_line("debug item add nuclear_rock")
+            ctx.dispatch_line("get nuclear-rock")
         for _ in range(5):
-            ctx.dispatch_line('debug item add ion_decay')
-            ctx.dispatch_line('get ion-decay')
-        ctx.dispatch_line('inventory')
+            ctx.dispatch_line("debug item add ion_decay")
+            ctx.dispatch_line("get ion-decay")
+        ctx.dispatch_line("inventory")
     wrap_out = buf.getvalue()
     item_lines = [
-        ln for ln in wrap_out.splitlines() if 'Cheese' in ln or 'Nuclear-Rock' in ln or 'Ion-Decay' in ln
+        ln
+        for ln in wrap_out.splitlines()
+        if "Cheese" in ln or "Nuclear-Rock" in ln or "Ion-Decay" in ln
     ]
     assert len(item_lines) >= 2
-    assert 'Nuclear-\nRock' not in wrap_out
+    assert "Nuclear-\nRock" not in wrap_out

--- a/tests/smoke/test_stats_page.py
+++ b/tests/smoke/test_stats_page.py
@@ -9,20 +9,22 @@ from mutants2.ui.theme import yellow, white
 
 
 def test_stats_page(tmp_path):
-    persistence.SAVE_PATH = tmp_path / 'save.json'
-    p = Player(year=2000, clazz='Warrior')
-    p.inventory.extend(['ion_decay', 'ion_decay', 'gold_chunk'])
+    persistence.SAVE_PATH = tmp_path / "save.json"
+    p = Player(year=2000, clazz="Warrior")
+    p.inventory.extend(["ion_decay", "ion_decay", "gold_chunk"])
     w = world_mod.World(seeded_years={2000})
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()
     ctx = make_context(p, w, save)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
-        ctx.dispatch_line('status')
+        ctx.dispatch_line("status")
     out = buf.getvalue()
-    assert yellow('Name: Vindeiatrix / Mutant Warrior') in out
-    assert yellow('Hit Points   : 40 / 40') in out
-    assert yellow('Ions         : 0') in out
-    assert yellow('Year A.D.     : 2000') in out
-    assert yellow("You are carrying the following items:  (Total Weight: 45 LB's)") in out
-    assert white('Ion-Decay, Ion-Decay (1), Gold-Chunk.') in out
+    assert yellow("Name: Vindeiatrix / Mutant Warrior") in out
+    assert yellow("Hit Points   : 40 / 40") in out
+    assert yellow("Ions         : 0") in out
+    assert yellow("Year A.D.     : 2000") in out
+    assert (
+        yellow("You are carrying the following items:  (Total Weight: 45 LB's)") in out
+    )
+    assert white("Ion-Decay, Ion-Decay\u00a0(1), Gold-Chunk.") in out

--- a/tests/test_player_ions_inventory_weight.py
+++ b/tests/test_player_ions_inventory_weight.py
@@ -8,21 +8,22 @@ from mutants2.ui.theme import yellow, white
 
 
 def test_inventory_weight_and_stats(cli_runner, tmp_path):
-    persistence.SAVE_PATH = Path(tmp_path) / '.mutants2' / 'save.json'
-    os.environ['HOME'] = str(tmp_path)
+    persistence.SAVE_PATH = Path(tmp_path) / ".mutants2" / "save.json"
+    os.environ["HOME"] = str(tmp_path)
 
     p = Player()
-    p.inventory.extend(['ion_decay', 'ion_decay', 'gold_chunk'])
+    p.inventory.extend(["ion_decay", "ion_decay", "gold_chunk"])
     w = World(seeded_years={2000})
     save = persistence.Save()
     persistence.save(p, w, save)
 
-    out = cli_runner.run_commands(['inventory', 'status'])
+    out = cli_runner.run_commands(["inventory", "status"])
 
     # Inventory header and weight
-    assert yellow("You are carrying the following items: (Total Weight: 45 LB's)") in out
-    assert white('Ion-Decay, Ion-Decay (1), Gold-Chunk.') in out
+    assert (
+        yellow("You are carrying the following items: (Total Weight: 45 LB's)") in out
+    )
+    assert white("Ion-Decay, Ion-Decay\u00a0(1), Gold-Chunk.") in out
 
     # Stats page ions
-    assert 'Ions         : 0' in out
-
+    assert "Ions         : 0" in out

--- a/tests/test_ui_parity.py
+++ b/tests/test_ui_parity.py
@@ -21,7 +21,7 @@ def test_single_item_and_stack():
     w = World({(2000, 0, 0): ["nuclear_thong", "nuclear_thong"]}, {2000})
     out = strip_ansi(render_room_at(w, 2000, 0, 0))
     assert "On the ground lies:" in out
-    assert "A Nuclear-Thong, A Nuclear-Thong (1)." in out
+    assert "A Nuclear-Thong, A Nuclear-Thong\u00a0(1)." in out
 
 
 def test_render_order_and_copy():


### PR DESCRIPTION
## Summary
- add ANSI-aware paragraph and list wrapping utilities
- keep numbered items intact with non-breaking spaces and token-aware joins
- clean up skull description and apply wrapping to item texts

## Testing
- `ruff check mutants2/ui/wrap.py mutants2/ui/render.py mutants2/render.py mutants2/cli/shell.py mutants2/engine/items.py tests/test_player_ions_inventory_weight.py tests/test_items_basic.py tests/test_ui_parity.py tests/smoke/test_render_enumeration_and_wrap.py tests/smoke/test_stats_page.py`
- `black mutants2/ui/wrap.py mutants2/ui/render.py mutants2/render.py mutants2/cli/shell.py mutants2/engine/items.py tests/test_player_ions_inventory_weight.py tests/test_items_basic.py tests/test_ui_parity.py tests/smoke/test_render_enumeration_and_wrap.py tests/smoke/test_stats_page.py`
- `pytest`
- ⚠️ `pre-commit run --files mutants2/ui/wrap.py mutants2/ui/render.py mutants2/render.py mutants2/cli/shell.py mutants2/engine/items.py tests/test_player_ions_inventory_weight.py tests/test_items_basic.py tests/test_ui_parity.py tests/smoke/test_render_enumeration_and_wrap.py tests/smoke/test_stats_page.py` (missing Python 3.11 interpreter)


------
https://chatgpt.com/codex/tasks/task_e_68bb4406e714832b9d90719e079715c4