### PR TITLE
Add basic equipment and weapon combat mechanics

### DIFF
--- a/mutants2/data/config.py
+++ b/mutants2/data/config.py
@@ -16,3 +16,6 @@ HEAL_K = {
     "warrior": 750,
     "mage": 1200,
 }
+
+# Armour Class divisor for damage reduction. Tunable constant.
+AC_DIVISOR = 1.30

--- a/mutants2/engine/items.py
+++ b/mutants2/engine/items.py
@@ -19,6 +19,8 @@ class ItemDef:
     riblets: Optional[int] = None
     spawnable: bool = False
     description_fn: Optional[Callable[[ItemInstance], str]] = None
+    base_power: int = 0
+    ac_bonus: int = 0
 
 
 REGISTRY: dict[str, ItemDef] = {}
@@ -33,26 +35,138 @@ def _add(
     *,
     spawnable: bool = False,
     description_fn: Optional[Callable[[ItemInstance], str]] = None,
+    base_power: int = 0,
+    ac_bonus: int = 0,
 ):
     REGISTRY[key] = ItemDef(
-        key, name, weight_lbs, ion_value, riblets, spawnable, description_fn
+        key,
+        name,
+        weight_lbs,
+        ion_value,
+        riblets,
+        spawnable,
+        description_fn,
+        base_power,
+        ac_bonus,
     )
 
 
 # Populate spawnable items
-_add("nuclear_decay", "Nuclear-Decay", 50, 85000, 60600, spawnable=True)
-_add("ion_decay", "Ion-Decay", 10, 18000, 19140, spawnable=True)
-_add("nuclear_rock", "Nuclear-Rock", 10, 15000, 49200, spawnable=True)
-_add("gold_chunk", "Gold-Chunk", 25, 25000, 49800, spawnable=True)
-_add("cheese", "Cheese", 1, 12000, 6060, spawnable=True)
-_add("light_spear", "Light-Spear", 10, 11000, None, spawnable=True)
-_add("monster_bait", "Monster-Bait", 10, 10000, spawnable=True)
-_add("nuclear_thong", "Nuclear-thong", 20, 13000, 600, spawnable=True)
-_add("ion_pack", "Ion-Pack", 50, 20000, 6, spawnable=True)
-_add("ion_booster", "Ion-Booster", 10, 13000, 300, spawnable=True)
-_add("nuclear_waste", "Nuclear-Waste", 30, 15000, 55200, spawnable=True)
-_add("cigarette_butt", "Cigarette-Butt", 1, 11000, 606, spawnable=True)
-_add("bottle_cap", "Bottle-Cap", 1, 22000, 606, spawnable=True)
+_add(
+    "nuclear_decay",
+    "Nuclear-Decay",
+    50,
+    85000,
+    60600,
+    spawnable=True,
+    base_power=77,
+)
+_add(
+    "ion_decay",
+    "Ion-Decay",
+    10,
+    18000,
+    19140,
+    spawnable=True,
+    base_power=10,
+)
+_add(
+    "nuclear_rock",
+    "Nuclear-Rock",
+    10,
+    15000,
+    49200,
+    spawnable=True,
+    base_power=7,
+)
+_add(
+    "gold_chunk",
+    "Gold-Chunk",
+    25,
+    25000,
+    49800,
+    spawnable=True,
+    base_power=17,
+)
+_add("cheese", "Cheese", 1, 12000, 6060, spawnable=True, base_power=4)
+_add(
+    "light_spear",
+    "Light-Spear",
+    10,
+    11000,
+    None,
+    spawnable=True,
+    base_power=3,
+)
+_add(
+    "monster_bait",
+    "Monster-Bait",
+    10,
+    10000,
+    spawnable=True,
+    base_power=2,
+)
+_add(
+    "nuclear_thong",
+    "Nuclear-thong",
+    20,
+    13000,
+    600,
+    spawnable=True,
+    base_power=5,
+)
+_add(
+    "ion_pack",
+    "Ion-Pack",
+    50,
+    20000,
+    6,
+    spawnable=True,
+    base_power=12,
+)
+_add(
+    "ion_booster",
+    "Ion-Booster",
+    10,
+    13000,
+    300,
+    spawnable=True,
+    base_power=5,
+)
+_add(
+    "nuclear_waste",
+    "Nuclear-Waste",
+    30,
+    15000,
+    55200,
+    spawnable=True,
+    base_power=7,
+)
+_add(
+    "cigarette_butt",
+    "Cigarette-Butt",
+    1,
+    11000,
+    606,
+    spawnable=True,
+    base_power=3,
+)
+_add(
+    "bottle_cap",
+    "Bottle-Cap",
+    1,
+    22000,
+    606,
+    spawnable=True,
+    base_power=14,
+)
+_add(
+    "bug_skin_armour",
+    "Bug-Skin-Armour",
+    8,
+    spawnable=True,
+    ac_bonus=3,
+)
 
 
 def describe_skull(inst: ItemInstance) -> str:
@@ -72,6 +186,7 @@ _add(
     25000,
     spawnable=False,
     description_fn=describe_skull,
+    base_power=4,
 )
 
 SPAWNABLE_KEYS = [k for k, v in REGISTRY.items() if v.spawnable]

--- a/mutants2/ui/help.py
+++ b/mutants2/ui/help.py
@@ -49,7 +49,7 @@ Examples
   do 7e3n; look
 """
 
-COMMANDS_HELP = """Commands: look, north, south, east, west, last, travel, class (or x), inventory, get, drop, convert, combat, exit, macro, @name, do
+COMMANDS_HELP = """Commands: look, north, south, east, west, last, travel, class (or x), inventory, get, drop, wear, remove, wield, convert, combat, exit, macro, @name, do
 
 Look
 ----
@@ -111,5 +111,20 @@ USAGE = {
         "This command is used to combat another player/monster in the game.",
         "",
         "Type COMBAT [name] to ready yourself for battle.",
+    ],
+    "wear": [
+        "Wear armor to increase your protection.",
+        "",
+        "Type WEAR [item] to put on a piece of armor.",
+    ],
+    "remove": [
+        "Remove the armor you are currently wearing.",
+        "",
+        "Type REMOVE [item] to take off your armor.",
+    ],
+    "wield": [
+        "Wield a weapon and strike if you are ready to combat.",
+        "",
+        "Type WIELD [item] to wield a weapon.",
     ],
 }

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -51,8 +51,17 @@ def print_yell(mon) -> str:
 
 def render_status(p) -> list[str]:
     from ..engine.player import CLASS_DISPLAY, class_key  # local import to avoid cycle
+    from ..engine import items as items_mod
 
     disp = CLASS_DISPLAY.get(class_key(p.clazz or ""), p.clazz or "")
+    armor_name = "Nothing."
+    if getattr(p, "worn_armor", None):
+        key = (
+            p.worn_armor.key
+            if hasattr(p.worn_armor, "key")
+            else p.worn_armor
+        )
+        armor_name = items_mod.display_name(key)
     lines = [
         yellow(f"Name: Vindeiatrix / Mutant {disp}"),
         yellow("Exhaustion   : 0"),
@@ -64,7 +73,7 @@ def render_status(p) -> list[str]:
         yellow(f"Exp. Points  : {p.exp}           Level: {p.level}"),
         yellow(f"Riblets      : {getattr(p, 'riblets', 0)}"),
         yellow(f"Ions         : {p.ions}"),
-        yellow(f"Wearing Armor: Nothing.  Armour Class: {p.ac_total}"),
+        yellow(f"Wearing Armor: {armor_name}  Armour Class: {p.ac_total}"),
         yellow(
             f"Ready to Combat: {p.ready_to_combat_name}" if p.ready_to_combat_name else "Ready to Combat: NO ONE"
         ),

--- a/tests/smoke/test_wear_wield_damage.py
+++ b/tests/smoke/test_wear_wield_damage.py
@@ -1,0 +1,88 @@
+import contextlib
+import tempfile
+import re
+import io
+from pathlib import Path
+
+from mutants2.engine import persistence
+from mutants2.engine.world import World
+from mutants2.engine.player import Player
+from mutants2.cli.shell import make_context
+from mutants2.engine import items
+
+
+BASE_POWERS = {
+    "monster_bait": 2,
+    "cigarette_butt": 3,
+    "light_spear": 3,
+    "skull": 4,
+    "cheese": 4,
+    "nuclear_thong": 5,
+    "ion_booster": 5,
+    "nuclear_rock": 7,
+    "nuclear_waste": 7,
+    "ion_decay": 10,
+    "ion_pack": 12,
+    "bottle_cap": 14,
+    "gold_chunk": 17,
+    "nuclear_decay": 77,
+}
+
+
+def run_commands(cmds, setup=None):
+    save = persistence.Save()
+    w = World()
+    w.year(2000)
+    p = Player(year=2000, clazz="Warrior")
+    if setup:
+        setup(w, p)
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with tempfile.TemporaryDirectory() as tmp:
+        persistence.SAVE_PATH = Path(tmp) / "save.json"
+        with contextlib.redirect_stdout(buf):
+            for c in cmds:
+                ctx.dispatch_line(c)
+    out = re.sub(r"\x1b\[[0-9;]*m", "", buf.getvalue())
+    buf.close()
+    return out, w, p
+
+
+def test_base_powers_and_armor():
+    for key, power in BASE_POWERS.items():
+        assert items.REGISTRY[key].base_power == power
+    assert items.REGISTRY["bug_skin_armour"].ac_bonus == 3
+
+
+def test_wear_and_remove_updates_ac():
+    def setup(w, p):
+        w.add_ground_item(2000, 0, 0, "bug_skin_armour")
+    out, w, p = run_commands([
+        "get bug",
+        "wear bug",
+        "status",
+        "remove",
+        "status",
+    ], setup=setup)
+    assert "You wear the Bug-Skin-Armour." in out
+    assert "You remove the Bug-Skin-Armour." in out
+    matches = re.findall(r"Wearing Armor: .*  Armour Class: (\d+)", out)
+    assert len(matches) == 2 and int(matches[0]) == int(matches[1]) + 3
+
+
+def test_wield_attack_damage():
+    def setup(w, p):
+        w.add_ground_item(2000, 0, 0, "nuclear_rock")
+        w.place_monster(2000, 0, 0, "mutant")
+    out, w, p = run_commands([
+        "get nuc",
+        "combat mutant",
+        "wield nuc",
+        "status",
+    ], setup=setup)
+    assert "You wield the Nuclear-Rock." in out
+    expected = items.REGISTRY["nuclear_rock"].base_power + p.strength // 10
+    pattern = rf"You hit Mutant-\d{{4}} for {expected} damage\.  \(temp\)"
+    assert re.search(pattern, out)
+    assert "Ready to Combat: NO ONE" in out
+    assert w.monster_here(2000, 0, 0) is None


### PR DESCRIPTION
## Summary
- tag all spawnable items with base melee power and add Bug-Skin-Armour
- support wearing armour, removing it, and wielding weapons with immediate attacks
- implement strength and armour class damage model with configurable divisor
- extend status and help text to show equipped gear
- add smoke tests for wear/wield flow and damage

## Testing
- `pytest tests/smoke/test_wear_wield_damage.py -q`
- `pytest tests/smoke/test_combat_ready_target.py::test_select_target_triggers_tick -q`
- `pytest tests/test_items_basic.py::test_pickup_and_drop_roundtrip -q`


------
https://chatgpt.com/codex/tasks/task_e_68bca95b71c0832b8afd21893e6a2ad4