### PR TITLE
Handle Bug-Skin aliasing and conversion

### DIFF
--- a/mutants2/engine/items_util.py
+++ b/mutants2/engine/items_util.py
@@ -1,9 +1,17 @@
 from typing import Union
 
 from mutants2.types import ItemInstance
+from . import items as items_mod
 
 
 def coerce_item(x: Union[ItemInstance, str]) -> ItemInstance:
     if isinstance(x, dict):
-        return x
-    return {"key": x, "enchant": None, "base_power": None, "ac_bonus": None, "meta": {}}
+        inst = x
+    else:
+        inst = {"key": x, "enchant": None, "base_power": None, "ac_bonus": None, "meta": {}}
+    meta = inst.setdefault("meta", {})
+    if "enchant_level" not in meta:
+        item = items_mod.REGISTRY.get(inst["key"])
+        if item and item.default_enchant_level:
+            meta["enchant_level"] = item.default_enchant_level
+    return inst

--- a/mutants2/engine/util/names.py
+++ b/mutants2/engine/util/names.py
@@ -1,0 +1,6 @@
+import re
+
+
+def norm_name(s: str) -> str:
+    """Normalize a name by lowercasing and stripping non-alphanumerics."""
+    return re.sub(r"[^a-z0-9]", "", s.lower())

--- a/tests/smoke/test_bug_skin_add_convert_look.py
+++ b/tests/smoke/test_bug_skin_add_convert_look.py
@@ -1,0 +1,60 @@
+import contextlib
+import datetime
+import io
+from pathlib import Path
+
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+from mutants2.cli.shell import make_context
+from mutants2.ui.theme import yellow
+
+
+def run_commands(cmds, path):
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True)
+    persistence.SAVE_PATH = path / "save.json"
+    w = world_mod.World(seeded_years={2000})
+    p = Player(year=2000, clazz="Warrior")
+    save = persistence.Save()
+    save.last_topup_date = datetime.date.today().isoformat()
+    ctx = make_context(p, w, save, dev=True)
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        for c in cmds:
+            ctx.dispatch_line(c)
+    out = buf.getvalue()
+    buf.close()
+    return out, w, p
+
+
+def test_debug_item_add_aliases_and_enchant(tmp_path):
+    aliases = ["bug-skin", "bug skin armour", "bug-skin-armour", "bugskin"]
+    for i, alias in enumerate(aliases):
+        out, _, _ = run_commands(
+            [f"debug item add {alias}", "get bug", "inventory"], tmp_path / str(i)
+        )
+        assert "Unknown item" not in out
+        assert "+1 Bug-Skin" in out
+
+
+def test_look_and_convert_inventory(tmp_path):
+    out, _, p = run_commands(
+        ["debug item add bug-skin", "get bug", "look bug", "convert bug-skin", "inventory", "status"],
+        tmp_path / "inv",
+    )
+    assert "possesses a magical aura" in out
+    assert yellow("The Bug-Skin vanishes with a flash!") in out
+    assert yellow("You convert the Bug-Skin into 22100 ions.") in out
+    assert "Bug-Skin" not in out.split("inventory")[-1]
+    assert p.ions == 22100
+
+
+def test_convert_worn_bug_skin(tmp_path):
+    out, _, p = run_commands(
+        ["debug item add bug-skin", "get bug", "wear bug", "convert bug", "inventory", "status"],
+        tmp_path / "worn",
+    )
+    assert yellow("The Bug-Skin vanishes with a flash!") in out
+    assert yellow("You convert the Bug-Skin into 22100 ions.") in out
+    assert "Bug-Skin" not in out.split("inventory")[-1]
+    assert p.ions == 22100

--- a/tests/smoke/test_equip_render_rewards.py
+++ b/tests/smoke/test_equip_render_rewards.py
@@ -38,7 +38,7 @@ def test_get_suppresses_room_render():
 
 def test_inventory_hides_worn_armor():
     def setup(w, p):
-        w.add_ground_item(2000, 0, 0, {"key": "bug_skin"})
+        w.add_ground_item(2000, 0, 0, {"key": "bug-skin"})
     out, _, _ = run_commands(
         ["get bug", "wear bug", "inventory", "remove", "inventory"], setup=setup
     )
@@ -67,7 +67,7 @@ def test_kill_rewards():
 
 def test_convert_bug_skin_plus_one_and_look():
     def setup(w, p):
-        p.inventory.append({"key": "bug_skin", "meta": {"enchant_level": 1}})
+        p.inventory.append({"key": "bug-skin", "meta": {"enchant_level": 1}})
     out, _, p = run_commands(["look bug", "convert bug", "status"], setup=setup)
     assert "possesses a magical aura" in out
     assert "+1 Bug-Skin" in out

--- a/tests/smoke/test_wear_wield_damage.py
+++ b/tests/smoke/test_wear_wield_damage.py
@@ -51,12 +51,12 @@ def run_commands(cmds, setup=None):
 def test_base_powers_and_armor():
     for key, power in BASE_POWERS.items():
         assert items.REGISTRY[key].base_power == power
-    assert items.REGISTRY["bug_skin"].ac_bonus == 3
+    assert items.REGISTRY["bug-skin"].ac_bonus == 3
 
 
 def test_wear_and_remove_updates_ac():
     def setup(w, p):
-        w.add_ground_item(2000, 0, 0, "bug_skin")
+        w.add_ground_item(2000, 0, 0, "bug-skin")
     out, w, p = run_commands([
         "get bug",
         "wear bug",


### PR DESCRIPTION
## Summary
- Canonicalize Bug-Skin with default +1 enchant and conversion value
- Normalize item names and aliases for debug add and convert commands
- Show enchant levels in inventory and convert worn Bug-Skin to ions

## Testing
- `pytest tests/smoke/test_bug_skin_add_convert_look.py tests/smoke/test_equip_render_rewards.py::test_convert_bug_skin_plus_one_and_look tests/smoke/test_wear_wield_damage.py::test_base_powers_and_armor tests/test_convert_command.py::test_convert_bottle_cap -q`


------
https://chatgpt.com/codex/tasks/task_e_68bcc27f9df4832baf5060238df8c2be