### PR TITLE
Refine item rendering and reset combat target

### DIFF
--- a/mutants2/engine/items_util.py
+++ b/mutants2/engine/items_util.py
@@ -1,17 +1,25 @@
-from typing import Union
+from typing import Any, Union, cast
 
 from mutants2.types import ItemInstance
 from . import items as items_mod
 
 
 def coerce_item(x: Union[ItemInstance, str]) -> ItemInstance:
-    if isinstance(x, dict):
-        inst = x
+    if isinstance(x, str):
+        it: ItemInstance = {"key": x}
     else:
-        inst = {"key": x, "enchant": None, "base_power": None, "ac_bonus": None, "meta": {}}
-    meta = inst.setdefault("meta", {})
-    if "enchant_level" not in meta:
-        item = items_mod.REGISTRY.get(inst["key"])
+        key = str(x.get("key")) if "key" in x else ""
+        it: ItemInstance = {"key": key}
+        if "enchant" in x and x["enchant"] is not None:
+            it["enchant"] = int(cast(int, x["enchant"]))
+        if "base_power" in x and x["base_power"] is not None:
+            it["base_power"] = int(cast(int, x["base_power"]))
+        if "ac_bonus" in x and x["ac_bonus"] is not None:
+            it["ac_bonus"] = int(cast(int, x["ac_bonus"]))
+        if "meta" in x and x["meta"] is not None:
+            it["meta"] = dict(cast(dict[str, Any], x["meta"]))
+    if "enchant" not in it:
+        item = items_mod.REGISTRY.get(it["key"])
         if item and item.default_enchant_level:
-            meta["enchant_level"] = item.default_enchant_level
-    return inst
+            it["enchant"] = item.default_enchant_level
+    return it

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -12,7 +12,7 @@ from . import items as items_mod, rng as rng_mod
 from .world import ALLOWED_CENTURIES
 from ..ui.theme import red
 from .items_resolver import get_item_def_by_key, resolve_key
-from ..ui.items_render import display_item_name
+from ..ui.items_render import display_item_name_plain
 
 
 INVENTORY_LIMIT = 10
@@ -154,7 +154,7 @@ class Player:
                 skipped = True
                 continue
             idef = get_item_def_by_key(key)
-            names.append(display_item_name(inst, idef, include_enchant=False))
+            names.append(display_item_name_plain(inst, idef))
         return names
 
     def inventory_display_names(self) -> list[str]:
@@ -171,7 +171,7 @@ class Player:
                 skipped = True
                 continue
             idef = get_item_def_by_key(key)
-            names.append(display_item_name(inst, idef))
+            names.append(display_item_name_plain(inst, idef))
         return names
 
     def inventory_weight_lbs(self) -> int:
@@ -282,9 +282,7 @@ class Player:
                         if inv_candidates:
                             victim = rng.choice(inv_candidates)
                             self.inventory.remove(victim)
-                            world.add_ground_item(
-                                self.year, self.x, self.y, victim
-                            )
+                            world.add_ground_item(self.year, self.x, self.y, victim)
                             victim_inst = coerce_item(victim)
                             vdef = get_item_def_by_key(resolve_key(victim_inst["key"]))
                             sack_name = vdef.name if vdef else victim_inst["key"]
@@ -311,7 +309,7 @@ class Player:
         if inv_obj is None or inv_inst is None:
             return None
         ion_value = item.ion_value
-        lvl = inv_inst.get("meta", {}).get("enchant_level", 0)
+        lvl = inv_inst.get("enchant", 0)
         if lvl > 0 and item.convert_value_ions is not None:
             ion_value = item.convert_value_ions
         if ion_value is None:

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -16,15 +16,13 @@ from typing import (
 
 from .types import (
     Direction,
-    ItemList,
-    ItemListMut,
     MonsterList,
     MonsterRec,
 )
 from mutants2.types import TileKey, ItemInstance
 from .items_util import coerce_item
 from .items_resolver import get_item_def_by_key
-from ..ui.items_render import display_item_name
+from ..ui.items_render import display_item_name_plain
 from . import monsters as monsters_mod, items as items_mod, rng as rng_mod
 from .ai import set_aggro
 from ..data.room_headers import ROOM_HEADERS
@@ -241,7 +239,7 @@ class World:
         names: list[str] = []
         for v in vals:
             idef = get_item_def_by_key(v["key"])
-            names.append(display_item_name(v, idef, include_enchant=False))
+            names.append(display_item_name_plain(v, idef))
         return names
 
     def items_on_ground(self, year: int, x: int, y: int) -> list[items_mod.ItemDef]:
@@ -367,9 +365,7 @@ class World:
         mid = self._id_alloc.allocate()
         self._monsters.setdefault((year, x, y), []).append(monsters_mod.spawn(key, mid))
 
-    def damage_monster(
-        self, year: int, x: int, y: int, dmg: int, player=None
-    ) -> bool:
+    def damage_monster(self, year: int, x: int, y: int, dmg: int, player=None) -> bool:
         coord = (year, x, y)
         lst = self._monsters.get(coord)
         if not lst:
@@ -383,7 +379,9 @@ class World:
             self._id_alloc.release(mid)
             if not lst:
                 self._monsters.pop(coord, None)
-            if player is not None and getattr(player, "ready_to_combat_id", None) == str(mid):
+            if player is not None and getattr(
+                player, "ready_to_combat_id", None
+            ) == str(mid):
                 player.ready_to_combat_id = None
                 player.ready_to_combat_name = None
             return True
@@ -399,7 +397,9 @@ class World:
         self._id_alloc.release(mid)
         if not lst:
             self._monsters.pop(coord, None)
-        if player is not None and getattr(player, "ready_to_combat_id", None) == str(mid):
+        if player is not None and getattr(player, "ready_to_combat_id", None) == str(
+            mid
+        ):
             player.ready_to_combat_id = None
             player.ready_to_combat_name = None
         return True

--- a/mutants2/types.py
+++ b/mutants2/types.py
@@ -1,11 +1,11 @@
-from typing import TypedDict, Tuple, Sequence, Mapping, Any, Required
+from typing import TypedDict, Tuple, Any, NotRequired, Required
 
 TileKey = Tuple[int, int, int]
 
 
 class ItemInstance(TypedDict, total=False):
     key: Required[str]
-    enchant: int | None
-    base_power: int | None
-    ac_bonus: int | None
-    meta: dict[str, Any]
+    enchant: NotRequired[int]
+    base_power: NotRequired[int]
+    ac_bonus: NotRequired[int]
+    meta: NotRequired[dict[str, Any]]

--- a/mutants2/ui/items_render.py
+++ b/mutants2/ui/items_render.py
@@ -1,19 +1,18 @@
-from mutants2.types import ItemInstance
 from mutants2.engine.items import ItemDef
+from mutants2.types import ItemInstance
 
 
-def display_item_name(it: ItemInstance, idef: ItemDef | None, include_enchant: bool = True) -> str:
-    if idef:
-        base = idef.name
-    else:
-        base = (
-            it.get("key", "").replace("_", " ").replace("-", " ").title().replace(" ", "-")
-        )
-    n = (
-        it.get("meta", {}).get("enchant_level")
-        or it.get("enchant")
-        or 0
+def display_item_name_plain(it: ItemInstance, idef: ItemDef | None) -> str:
+    base = (
+        (idef.name if idef else it.get("key", ""))
+        .replace("-", " ")
+        .title()
+        .replace(" ", "-")
     )
-    if include_enchant and n > 0:
-        return f"+{n} {base}"
     return base
+
+
+def display_item_name_with_plus(it: ItemInstance, idef: ItemDef | None) -> str:
+    name = display_item_name_plain(it, idef)
+    n = it.get("enchant") or 0
+    return f"+{n} {name}" if n > 0 else name

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -55,17 +55,16 @@ def print_yell(mon) -> str:
 
 def render_status(p) -> list[str]:
     from ..engine.player import CLASS_DISPLAY, class_key  # local import to avoid cycle
-    from ..engine import items as items_mod
     from ..engine.items_resolver import get_item_def_by_key
     from ..engine.items_util import coerce_item
-    from .items_render import display_item_name
+    from .items_render import display_item_name_plain
 
     disp = CLASS_DISPLAY.get(class_key(p.clazz or ""), p.clazz or "")
     armor_name = "Nothing."
     if getattr(p, "worn_armor", None):
         inst = coerce_item(p.worn_armor)
         idef = get_item_def_by_key(inst["key"])
-        armor_name = display_item_name(inst, idef)
+        armor_name = display_item_name_plain(inst, idef)
     lines = [
         yellow(f"Name: Vindeiatrix / Mutant {disp}"),
         yellow("Exhaustion   : 0"),
@@ -76,16 +75,14 @@ def render_status(p) -> list[str]:
             f"Dex: {fmt(p.dexterity):<2}   Con: {fmt(p.constitution):<2}   Cha: {fmt(p.charisma):<2}"
         ),
         yellow(f"Hit Points   : {fmt(p.hp)} / {fmt(p.max_hp)}"),
-        yellow(
-            f"Exp. Points  : {fmt(p.exp)}           Level: {fmt(p.level)}"
-        ),
+        yellow(f"Exp. Points  : {fmt(p.exp)}           Level: {fmt(p.level)}"),
         yellow(f"Riblets      : {fmt(getattr(p, 'riblets', 0))}"),
         yellow(f"Ions         : {fmt(p.ions)}"),
+        yellow(f"Wearing Armor: {armor_name}  Armour Class: {fmt(p.ac_total)}"),
         yellow(
-            f"Wearing Armor: {armor_name}  Armour Class: {fmt(p.ac_total)}"
-        ),
-        yellow(
-            f"Ready to Combat: {p.ready_to_combat_name}" if p.ready_to_combat_name else "Ready to Combat: NO ONE"
+            f"Ready to Combat: {p.ready_to_combat_name}"
+            if p.ready_to_combat_name
+            else "Ready to Combat: NO ONE"
         ),
         yellow("Readied Spell : No spell memorized."),
         yellow(f"Year A.D.     : {fmt(p.year)}"),
@@ -98,5 +95,9 @@ def render_kill_block(name: str, xp: int, riblets: int, ions: int) -> None:
     """Render the red kill message block for monster deaths."""
     print(red(f"You have slain {name}!"))
     print(red(f"Your experience points are increased by {fmt(xp)}!"))
-    print(red(f"You collect {fmt(riblets)} Riblets and {fmt(ions)} ions from the slain body."))
+    print(
+        red(
+            f"You collect {fmt(riblets)} Riblets and {fmt(ions)} ions from the slain body."
+        )
+    )
     print("***")

--- a/tests/smoke/test_bug_skin_add_convert_look.py
+++ b/tests/smoke/test_bug_skin_add_convert_look.py
@@ -31,30 +31,48 @@ def test_debug_item_add_aliases_and_enchant(tmp_path):
     aliases = ["bug-skin", "bug skin armour", "bug-skin-armour", "bugskin"]
     for i, alias in enumerate(aliases):
         out, _, _ = run_commands(
-            [f"debug item add {alias}", "get bug", "inventory"], tmp_path / str(i)
+            [f"debug item add {alias}", "get bug", "look bug", "inventory"],
+            tmp_path / str(i),
         )
         assert "Unknown item" not in out
         assert "+1 Bug-Skin" in out
+        assert "+1 Bug-Skin" not in out.split("inventory")[-1]
 
 
 def test_look_and_convert_inventory(tmp_path):
     out, _, p = run_commands(
-        ["debug item add bug-skin", "get bug", "look bug", "convert bug-skin", "inventory", "status"],
+        [
+            "debug item add bug-skin",
+            "get bug",
+            "look bug",
+            "convert bug-skin",
+            "inventory",
+            "status",
+        ],
         tmp_path / "inv",
     )
     assert "possesses a magical aura" in out
     assert yellow("The Bug-Skin vanishes with a flash!") in out
     assert yellow("You convert the Bug-Skin into 22100 ions.") in out
-    assert "Bug-Skin" not in out.split("inventory")[-1]
+    inv_block = out.split("inventory")[-1].split("status")[0]
+    assert "Bug-Skin" not in inv_block
     assert p.ions == 22100
 
 
 def test_convert_worn_bug_skin(tmp_path):
     out, _, p = run_commands(
-        ["debug item add bug-skin", "get bug", "wear bug", "convert bug", "inventory", "status"],
+        [
+            "debug item add bug-skin",
+            "get bug",
+            "wear bug",
+            "convert bug",
+            "inventory",
+            "status",
+        ],
         tmp_path / "worn",
     )
     assert yellow("The Bug-Skin vanishes with a flash!") in out
     assert yellow("You convert the Bug-Skin into 22100 ions.") in out
-    assert "Bug-Skin" not in out.split("inventory")[-1]
+    inv_block = out.split("inventory")[-1].split("status")[0]
+    assert "Bug-Skin" not in inv_block
     assert p.ions == 22100

--- a/tests/smoke/test_equip_render_rewards.py
+++ b/tests/smoke/test_equip_render_rewards.py
@@ -8,7 +8,7 @@ from mutants2.engine import persistence
 from mutants2.engine.world import World
 from mutants2.engine.player import Player
 from mutants2.cli.shell import make_context
-from mutants2.types import ItemInstance
+
 
 def run_commands(cmds, setup=None):
     save = persistence.Save()
@@ -28,17 +28,21 @@ def run_commands(cmds, setup=None):
     buf.close()
     return out, w, p
 
+
 def test_get_suppresses_room_render():
     def setup(w, p):
         w.add_ground_item(2000, 0, 0, {"key": "skull"})
+
     out, _, _ = run_commands(["get skull"], setup=setup)
     assert "You pick up Skull." in out
     assert "You are here." not in out
     assert "Compass:" not in out
 
+
 def test_inventory_hides_worn_armor():
     def setup(w, p):
         w.add_ground_item(2000, 0, 0, {"key": "bug-skin"})
+
     out, _, _ = run_commands(
         ["get bug", "wear bug", "inventory", "remove", "inventory"], setup=setup
     )
@@ -48,26 +52,32 @@ def test_inventory_hides_worn_armor():
     assert "Bug-Skin" not in first
     assert "Bug-Skin" in second
 
+
 def test_wield_without_target_suppresses_line():
     def setup(w, p):
         w.add_ground_item(2000, 0, 0, {"key": "light_spear"})
+
     out, _, _ = run_commands(["get light", "wield light"], setup=setup)
     assert "You wield the Light-Spear." not in out
     assert "You're not ready to combat anyone." in out
+
 
 def test_kill_rewards():
     def setup(w, p):
         w.add_ground_item(2000, 0, 0, {"key": "light_spear"})
         w.place_monster(2000, 0, 0, "mutant")
+
     out, _, p = run_commands(
         ["get light", "combat mutant", "wield light", "status"], setup=setup
     )
     assert "You gain 20000 riblets and 20000 ions." in out
     assert p.riblets == 20000 and p.ions == 20000
 
+
 def test_convert_bug_skin_plus_one_and_look():
     def setup(w, p):
-        p.inventory.append({"key": "bug-skin", "meta": {"enchant_level": 1}})
+        p.inventory.append({"key": "bug-skin", "enchant": 1})
+
     out, _, p = run_commands(["look bug", "convert bug", "status"], setup=setup)
     assert "possesses a magical aura" in out
     assert "+1 Bug-Skin" in out

--- a/tests/test_items_prefix_and_abbrev.py
+++ b/tests/test_items_prefix_and_abbrev.py
@@ -10,10 +10,10 @@ from mutants2.ui.theme import yellow
 
 @pytest.fixture
 def tile_with_item(tmp_path):
-    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
-    os.environ['HOME'] = str(tmp_path)
+    persistence.SAVE_PATH = tmp_path / ".mutants2" / "save.json"
+    os.environ["HOME"] = str(tmp_path)
     p = Player()
-    w = World({(2000, 0, 0): ['nuclear_thong']}, {2000})
+    w = World({(2000, 0, 0): ["nuclear_thong"]}, {2000})
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()
     persistence.save(p, w, save)
@@ -22,10 +22,10 @@ def tile_with_item(tmp_path):
 
 @pytest.fixture
 def inventory_with_item(tmp_path):
-    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
-    os.environ['HOME'] = str(tmp_path)
+    persistence.SAVE_PATH = tmp_path / ".mutants2" / "save.json"
+    os.environ["HOME"] = str(tmp_path)
     p = Player()
-    p.inventory.append('nuclear_thong')
+    p.inventory.append("nuclear_thong")
     w = World(seeded_years={2000})
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()
@@ -35,10 +35,10 @@ def inventory_with_item(tmp_path):
 
 @pytest.fixture
 def inventory_with_ion_items(tmp_path):
-    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
-    os.environ['HOME'] = str(tmp_path)
+    persistence.SAVE_PATH = tmp_path / ".mutants2" / "save.json"
+    os.environ["HOME"] = str(tmp_path)
     p = Player()
-    p.inventory.extend(['ion_decay', 'ion_pack'])
+    p.inventory.extend(["ion_decay", "ion_pack"])
     w = World(seeded_years={2000})
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()
@@ -49,13 +49,13 @@ def inventory_with_ion_items(tmp_path):
 def test_get_does_not_render(cli_runner, tile_with_item):
     out = cli_runner.run_commands(["look", "get nuc"])
     assert out.count("***") >= 2
-    assert "You pick up Nuclear-thong." in out
+    assert "You pick up Nuclear-Thong." in out
 
 
 def test_drop_does_not_render(cli_runner, inventory_with_item):
     out = cli_runner.run_commands(["dro nuc"])
     assert out.count("***") == 1
-    assert "You drop Nuclear-thong." in out
+    assert "You drop Nuclear-Thong." in out
 
 
 def test_item_prefix_first_match_cli_runner(cli_runner, inventory_with_ion_items):
@@ -75,4 +75,3 @@ def test_travel_suppresses_render(cli_runner):
     out = cli_runner.run_commands(["tra 2100"])
     assert "ZAAAAPPPPP!!" in out
     assert out.count("Compass:") == 1
-

--- a/tests/test_prefix_rules.py
+++ b/tests/test_prefix_rules.py
@@ -75,14 +75,15 @@ def test_directions_special(cli):
 
 def test_item_prefix_first_match(cli, world_with_items):
     out = cli.run(["get n"])
-    assert "You pick up Nuclear-thong." in out
+    assert "You pick up Nuclear-Thong." in out
     out2 = cli.run(["dro nuc"])
-    assert "You drop Nuclear-thong." in out2
+    assert "You drop Nuclear-Thong." in out2
 
 
 def test_look_monster_precedence(cli, world_with_monster_and_item_N_on_tile):
     out = cli.run(["loo n"])
     assert "It's a Night-Stalker." in out
+
 
 def test_look_direction_fallback(cli):
     out = cli.run(["loo e"])


### PR DESCRIPTION
## Summary
- split item name rendering into plain and +N variants
- hide enchant bonuses in inventory and stats, reveal via look only
- clear Ready to Combat on class change or exit and ensure save
- tighten ItemInstance typing and item coercion

## Testing
- `black mutants2/types.py mutants2/engine/items_util.py mutants2/ui/items_render.py mutants2/engine/world.py mutants2/engine/player.py mutants2/ui/render.py mutants2/cli/shell.py tests/smoke/test_bug_skin_add_convert_look.py tests/smoke/test_equip_render_rewards.py`
- `ruff check mutants2/types.py mutants2/engine/items_util.py mutants2/ui/items_render.py mutants2/engine/world.py mutants2/engine/player.py mutants2/ui/render.py mutants2/cli/shell.py tests/smoke/test_bug_skin_add_convert_look.py tests/smoke/test_equip_render_rewards.py`
- `pyright mutants2 --level warning`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bcd479cc28832bbb387d67277a1b10