### PR TITLE
Hide enchantment bonus outside of look

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -11,7 +11,10 @@ from ..engine.items_resolver import (
     get_item_def_by_key,
     resolve_key,
 )
-from ..ui.items_render import display_item_name
+from ..ui.items_render import (
+    display_item_name_plain,
+    display_item_name_with_plus,
+)
 from ..engine.items_util import coerce_item
 from ..engine.render import render_room_view
 from ..engine import render as render_mod
@@ -393,7 +396,7 @@ def make_context(p, w, save, *, dev: bool = False):
             print(f'No item in inventory matching "{raw}".')
             return False
         idef = get_item_def_by_key(key)
-        name = display_item_name(inst_match, idef)
+        name = display_item_name_plain(inst_match, idef)
         ok, msg, sack_name, gift_name = p.drop_to_ground(idef.name if idef else key, w)
         print(f"You drop {name}." if ok else (msg or "You can’t drop that here."))
         if sack_name:
@@ -445,10 +448,10 @@ def make_context(p, w, save, *, dev: bool = False):
         if p.worn_armor:
             old_inst = coerce_item(p.worn_armor)
             old_def = get_item_def_by_key(old_inst["key"])
-            print(yellow(f"You remove the {display_item_name(old_inst, old_def, include_enchant=False)}."))
+            print(yellow(f"You remove the {display_item_name_plain(old_inst, old_def)}."))
         p.worn_armor = inst_match
         p.recompute_ac()
-        print(yellow(f"You wear the {display_item_name(inst_match, idef, include_enchant=False)}."))
+        print(yellow(f"You wear the {display_item_name_plain(inst_match, idef)}."))
         context._needs_render = False
         context._suppress_room_render = True
         return False
@@ -466,7 +469,7 @@ def make_context(p, w, save, *, dev: bool = False):
             return False
         inst = coerce_item(p.worn_armor)
         idef = get_item_def_by_key(inst["key"])
-        name = display_item_name(inst, idef, include_enchant=False)
+        name = display_item_name_plain(inst, idef)
         p.worn_armor = None
         p.recompute_ac()
         print(yellow("***"))
@@ -515,7 +518,7 @@ def make_context(p, w, save, *, dev: bool = False):
             context._suppress_room_render = True
             return False
         print(yellow("***"))
-        print(yellow(f"You wield the {display_item_name(inst_match, idef, include_enchant=False)}."))
+        print(yellow(f"You wield the {display_item_name_plain(inst_match, idef)}."))
         key = inst_match["key"]
         dmg, killed, name_mon = combat.player_attack(p, w, key)
         print(yellow("***"))
@@ -607,9 +610,9 @@ def make_context(p, w, save, *, dev: bool = False):
             lvl = inst_match.get("meta", {}).get("enchant_level")
             if lvl is None:
                 lvl = inst_match.get("enchant") or 0
-            base_name = display_item_name(inst_match, idef, include_enchant=False)
+            base_name = display_item_name_plain(inst_match, idef)
             if lvl > 0:
-                ench_name = display_item_name(inst_match, idef)
+                ench_name = display_item_name_with_plus(inst_match, idef)
                 print(
                     yellow(
                         f"The {base_name} possesses a magical aura. "

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -12,7 +12,7 @@ from . import items as items_mod, rng as rng_mod
 from .world import ALLOWED_CENTURIES
 from ..ui.theme import red
 from .items_resolver import get_item_def_by_key, resolve_key
-from ..ui.items_render import display_item_name
+from ..ui.items_render import display_item_name_plain
 
 
 INVENTORY_LIMIT = 10
@@ -154,7 +154,7 @@ class Player:
                 skipped = True
                 continue
             idef = get_item_def_by_key(key)
-            names.append(display_item_name(inst, idef, include_enchant=False))
+            names.append(display_item_name_plain(inst, idef))
         return names
 
     def inventory_display_names(self) -> list[str]:
@@ -171,7 +171,7 @@ class Player:
                 skipped = True
                 continue
             idef = get_item_def_by_key(key)
-            names.append(display_item_name(inst, idef))
+            names.append(display_item_name_plain(inst, idef))
         return names
 
     def inventory_weight_lbs(self) -> int:

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -24,7 +24,7 @@ from .types import (
 from mutants2.types import TileKey, ItemInstance
 from .items_util import coerce_item
 from .items_resolver import get_item_def_by_key
-from ..ui.items_render import display_item_name
+from ..ui.items_render import display_item_name_plain
 from . import monsters as monsters_mod, items as items_mod, rng as rng_mod
 from .ai import set_aggro
 from ..data.room_headers import ROOM_HEADERS
@@ -241,7 +241,7 @@ class World:
         names: list[str] = []
         for v in vals:
             idef = get_item_def_by_key(v["key"])
-            names.append(display_item_name(v, idef, include_enchant=False))
+            names.append(display_item_name_plain(v, idef))
         return names
 
     def items_on_ground(self, year: int, x: int, y: int) -> list[items_mod.ItemDef]:

--- a/mutants2/ui/items_render.py
+++ b/mutants2/ui/items_render.py
@@ -2,18 +2,31 @@ from mutants2.types import ItemInstance
 from mutants2.engine.items import ItemDef
 
 
-def display_item_name(it: ItemInstance, idef: ItemDef | None, include_enchant: bool = True) -> str:
+def _base_item_name(it: ItemInstance, idef: ItemDef | None) -> str:
+    """Return the canonical display name for an item without enchant."""
     if idef:
-        base = idef.name
-    else:
-        base = (
-            it.get("key", "").replace("_", " ").replace("-", " ").title().replace(" ", "-")
-        )
+        return idef.name
+    return (
+        it.get("key", "").replace("_", " ")
+        .replace("-", " ")
+        .title()
+        .replace(" ", "-")
+    )
+
+
+def display_item_name_plain(it: ItemInstance, idef: ItemDef | None) -> str:
+    """Display helper for inventory and stats (no +N prefix)."""
+    return _base_item_name(it, idef)
+
+
+def display_item_name_with_plus(it: ItemInstance, idef: ItemDef | None) -> str:
+    """Display helper for look command (includes +N when enchanted)."""
+    base = _base_item_name(it, idef)
     n = (
         it.get("meta", {}).get("enchant_level")
         or it.get("enchant")
         or 0
     )
-    if include_enchant and n > 0:
+    if n > 0:
         return f"+{n} {base}"
     return base

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -58,14 +58,14 @@ def render_status(p) -> list[str]:
     from ..engine import items as items_mod
     from ..engine.items_resolver import get_item_def_by_key
     from ..engine.items_util import coerce_item
-    from .items_render import display_item_name
+    from .items_render import display_item_name_plain
 
     disp = CLASS_DISPLAY.get(class_key(p.clazz or ""), p.clazz or "")
     armor_name = "Nothing."
     if getattr(p, "worn_armor", None):
         inst = coerce_item(p.worn_armor)
         idef = get_item_def_by_key(inst["key"])
-        armor_name = display_item_name(inst, idef)
+        armor_name = display_item_name_plain(inst, idef)
     lines = [
         yellow(f"Name: Vindeiatrix / Mutant {disp}"),
         yellow("Exhaustion   : 0"),

--- a/tests/smoke/test_bug_skin_add_convert_look.py
+++ b/tests/smoke/test_bug_skin_add_convert_look.py
@@ -9,7 +9,7 @@ from mutants2.cli.shell import make_context
 from mutants2.ui.theme import yellow
 
 
-def run_commands(cmds, path):
+def run_commands(cmds, path, setup=None):
     path = Path(path)
     path.mkdir(parents=True, exist_ok=True)
     persistence.SAVE_PATH = path / "save.json"
@@ -17,6 +17,8 @@ def run_commands(cmds, path):
     p = Player(year=2000, clazz="Warrior")
     save = persistence.Save()
     save.last_topup_date = datetime.date.today().isoformat()
+    if setup:
+        setup(w, p)
     ctx = make_context(p, w, save, dev=True)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
@@ -31,10 +33,14 @@ def test_debug_item_add_aliases_and_enchant(tmp_path):
     aliases = ["bug-skin", "bug skin armour", "bug-skin-armour", "bugskin"]
     for i, alias in enumerate(aliases):
         out, _, _ = run_commands(
-            [f"debug item add {alias}", "get bug", "inventory"], tmp_path / str(i)
+            [f"debug item add {alias}", "get bug", "look bug", "inventory"],
+            tmp_path / str(i),
         )
         assert "Unknown item" not in out
         assert "+1 Bug-Skin" in out
+        inv_out = out.split("inventory")[-1]
+        assert "+1 Bug-Skin" not in inv_out
+        assert "Bug-Skin" in inv_out
 
 
 def test_look_and_convert_inventory(tmp_path):
@@ -58,3 +64,14 @@ def test_convert_worn_bug_skin(tmp_path):
     assert yellow("You convert the Bug-Skin into 22100 ions.") in out
     assert "Bug-Skin" not in out.split("inventory")[-1]
     assert p.ions == 22100
+
+
+def test_inventory_stacks_enchanted_variants(tmp_path):
+    def setup(w, p):
+        p.inventory.append({"key": "bug-skin", "meta": {"enchant_level": 1}})
+        p.inventory.append({"key": "bug-skin", "meta": {"enchant_level": 2}})
+
+    out, _, _ = run_commands(["inventory"], tmp_path / "stack", setup=setup)
+    inv_out = out.split("inventory")[-1].replace("\u00a0", " ")
+    assert "Bug-Skin" in inv_out
+    assert "Bug-Skin (1)" in inv_out


### PR DESCRIPTION
## Summary
- Add `display_item_name_plain` and `display_item_name_with_plus` renderers
- Use plain renderer for stats, inventory, and item command echoes
- Reveal enchantment only in `look` and stack enchanted variants together

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd7399512c832bb2a2c096ea778290