### PR TITLE
Refactor items and introduce geared monster roster

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -583,7 +583,13 @@ def make_context(p, w, save, *, dev: bool = False):
         ]
         mname = monsters.first_mon_prefix(q, here_monsters)
         if mname:
+            level = 0
+            for m in w.monsters_here(p.year, p.x, p.y):
+                if monsters.REGISTRY[m["key"]].name == mname:
+                    level = int(cast(int, m.get("level", 0)))
+                    break
             print(f"It's a {mname}.")
+            print(yellow(f"It appears to be level {level}."))
             return True
 
         ground_objs = w.ground.get((p.year, p.x, p.y), [])
@@ -607,9 +613,7 @@ def make_context(p, w, save, *, dev: bool = False):
         if inst_match:
             print(yellow("***"))
             idef = get_item_def_by_key(inst_match["key"])
-            lvl = inst_match.get("meta", {}).get("enchant_level")
-            if lvl is None:
-                lvl = inst_match.get("enchant") or 0
+            lvl = inst_match.get("enchant") or 0
             base_name = display_item_name_plain(inst_match, idef)
             if lvl > 0:
                 ench_name = display_item_name_with_plus(inst_match, idef)
@@ -865,9 +869,9 @@ def make_context(p, w, save, *, dev: bool = False):
                         lvl = enchant
                         if lvl is None:
                             lvl = idef.default_enchant_level
-                        inst = {"key": key}
+                        inst: ItemInstance = {"key": key}
                         if lvl:
-                            inst["meta"] = {"enchant_level": lvl}
+                            inst["enchant"] = lvl
                         w.add_ground_item(p.year, p.x, p.y, inst)
                     print(f"OK: added {count} x {idef.name}.")
                 elif args[:2] == ["item", "clear"]:

--- a/mutants2/engine/items.py
+++ b/mutants2/engine/items.py
@@ -198,6 +198,88 @@ _add(
     base_power=4,
 )
 
+# Monster gear ---------------------------------------------------------------
+_add(
+    "iron-sabre",
+    "Iron-Sabre",
+    8,
+    convert_value_ions=15000,
+    base_power=8,
+    default_enchant_level=1,
+)
+_add(
+    "plate-jacket",
+    "Plate-Jacket",
+    12,
+    convert_value_ions=23000,
+    ac_bonus=10,
+    default_enchant_level=1,
+)
+_add(
+    "plasma-knife",
+    "Plasma-Knife",
+    5,
+    convert_value_ions=17000,
+    base_power=9,
+    default_enchant_level=1,
+)
+_add(
+    "woven-plasmacoat",
+    "Woven-Plasmacoat",
+    9,
+    convert_value_ions=24000,
+    ac_bonus=11,
+    default_enchant_level=1,
+)
+_add(
+    "time-rod",
+    "Time-Rod",
+    6,
+    convert_value_ions=18000,
+    base_power=8,
+    default_enchant_level=1,
+)
+_add(
+    "chrono-robes",
+    "Chrono-Robes",
+    7,
+    convert_value_ions=25000,
+    ac_bonus=10,
+    default_enchant_level=1,
+)
+_add(
+    "ion-talons",
+    "Ion-Talons",
+    5,
+    convert_value_ions=19000,
+    base_power=10,
+    default_enchant_level=1,
+)
+_add(
+    "phase-carapace",
+    "Phase-Carapace",
+    10,
+    convert_value_ions=26000,
+    ac_bonus=12,
+    default_enchant_level=1,
+)
+_add(
+    "gravity-hammer",
+    "Gravity-Hammer",
+    12,
+    convert_value_ions=21000,
+    base_power=12,
+    default_enchant_level=1,
+)
+_add(
+    "mass-plate",
+    "Mass-Plate",
+    11,
+    convert_value_ions=28000,
+    ac_bonus=13,
+    default_enchant_level=1,
+)
+
 SPAWNABLE_KEYS = [k for k, v in REGISTRY.items() if v.spawnable]
 
 __all__ = [

--- a/mutants2/engine/items_util.py
+++ b/mutants2/engine/items_util.py
@@ -1,17 +1,19 @@
 from typing import Union
 
 from mutants2.types import ItemInstance
-from . import items as items_mod
 
 
 def coerce_item(x: Union[ItemInstance, str]) -> ItemInstance:
-    if isinstance(x, dict):
-        inst = x
-    else:
-        inst = {"key": x, "enchant": None, "base_power": None, "ac_bonus": None, "meta": {}}
-    meta = inst.setdefault("meta", {})
-    if "enchant_level" not in meta:
-        item = items_mod.REGISTRY.get(inst["key"])
-        if item and item.default_enchant_level:
-            meta["enchant_level"] = item.default_enchant_level
-    return inst
+    if isinstance(x, str):
+        return {"key": x}
+
+    out: ItemInstance = {"key": str(x.get("key", ""))}
+    if "enchant" in x and x["enchant"] is not None:
+        out["enchant"] = int(x["enchant"])
+    if "base_power" in x and x["base_power"] is not None:
+        out["base_power"] = int(x["base_power"])
+    if "ac_bonus" in x and x["ac_bonus"] is not None:
+        out["ac_bonus"] = int(x["ac_bonus"])
+    if "meta" in x and isinstance(x["meta"], dict):
+        out["meta"] = dict(x["meta"])
+    return out

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -311,7 +311,7 @@ class Player:
         if inv_obj is None or inv_inst is None:
             return None
         ion_value = item.ion_value
-        lvl = inv_inst.get("meta", {}).get("enchant_level", 0)
+        lvl = inv_inst.get("enchant", 0)
         if lvl > 0 and item.convert_value_ions is not None:
             ion_value = item.convert_value_ions
         if ion_value is None:

--- a/mutants2/engine/world.py
+++ b/mutants2/engine/world.py
@@ -198,6 +198,7 @@ class World:
                     lst.append(m)
                 if lst:
                     self._monsters[coord] = lst
+        monsters_mod.seed_monsters(self)
         self._recent_monster_moves: list[tuple[int, int, int, int, int]] = []
         self.turn = turn
         self._room_headers: Dict[Tuple[int, int, int], str] = {}
@@ -379,6 +380,16 @@ class World:
         hp_val = int(cast(int, m["hp"]))
         m["hp"] = max(0, hp_val - max(0, dmg))
         if int(cast(int, m["hp"])) <= 0:
+            weapon = m.get("wielded_weapon")
+            armor = m.get("worn_armor")
+            if weapon:
+                self.add_ground_item(
+                    year, x, y, coerce_item(cast(ItemInstance | str, weapon))
+                )
+            if armor:
+                self.add_ground_item(
+                    year, x, y, coerce_item(cast(ItemInstance | str, armor))
+                )
             lst.pop(0)
             self._id_alloc.release(mid)
             if not lst:
@@ -584,10 +595,7 @@ class World:
                 raise ValueError("start tile (0,0) must be open")
             self.years[value] = Year(value, grid)
             gen.seed_items(self, value, grid)
-            had_start = self.has_monster(value, 0, 0)
-            gen.seed_monsters_for_year(self, value, self.global_seed)
-            # Ensure starting tile is clear unless a monster was explicitly placed
-            if not had_start:
-                while self.remove_monster(value, 0, 0):
-                    pass
+            # Ensure starting tile is clear
+            while self.remove_monster(value, 0, 0):
+                pass
         return self.years[value]

--- a/mutants2/types.py
+++ b/mutants2/types.py
@@ -1,11 +1,11 @@
-from typing import TypedDict, Tuple, Sequence, Mapping, Any, Required
+from typing import Any, NotRequired, TypedDict, Tuple, Sequence, Mapping, Required
 
 TileKey = Tuple[int, int, int]
 
 
 class ItemInstance(TypedDict, total=False):
     key: Required[str]
-    enchant: int | None
-    base_power: int | None
-    ac_bonus: int | None
-    meta: dict[str, Any]
+    enchant: NotRequired[int]
+    base_power: NotRequired[int]
+    ac_bonus: NotRequired[int]
+    meta: NotRequired[dict[str, Any]]

--- a/mutants2/ui/items_render.py
+++ b/mutants2/ui/items_render.py
@@ -22,11 +22,7 @@ def display_item_name_plain(it: ItemInstance, idef: ItemDef | None) -> str:
 def display_item_name_with_plus(it: ItemInstance, idef: ItemDef | None) -> str:
     """Display helper for look command (includes +N when enchanted)."""
     base = _base_item_name(it, idef)
-    n = (
-        it.get("meta", {}).get("enchant_level")
-        or it.get("enchant")
-        or 0
-    )
+    n = it.get("enchant", 0)
     if n > 0:
         return f"+{n} {base}"
     return base

--- a/tests/smoke/test_bug_skin_add_convert_look.py
+++ b/tests/smoke/test_bug_skin_add_convert_look.py
@@ -68,8 +68,8 @@ def test_convert_worn_bug_skin(tmp_path):
 
 def test_inventory_stacks_enchanted_variants(tmp_path):
     def setup(w, p):
-        p.inventory.append({"key": "bug-skin", "meta": {"enchant_level": 1}})
-        p.inventory.append({"key": "bug-skin", "meta": {"enchant_level": 2}})
+        p.inventory.append({"key": "bug-skin", "enchant": 1})
+        p.inventory.append({"key": "bug-skin", "enchant": 2})
 
     out, _, _ = run_commands(["inventory"], tmp_path / "stack", setup=setup)
     inv_out = out.split("inventory")[-1].replace("\u00a0", " ")

--- a/tests/smoke/test_equip_render_rewards.py
+++ b/tests/smoke/test_equip_render_rewards.py
@@ -67,7 +67,7 @@ def test_kill_rewards():
 
 def test_convert_bug_skin_plus_one_and_look():
     def setup(w, p):
-        p.inventory.append({"key": "bug-skin", "meta": {"enchant_level": 1}})
+        p.inventory.append({"key": "bug-skin", "enchant": 1})
     out, _, p = run_commands(["look bug", "convert bug", "status"], setup=setup)
     assert "possesses a magical aura" in out
     assert "+1 Bug-Skin" in out

--- a/tests/test_combat_minimal.py
+++ b/tests/test_combat_minimal.py
@@ -14,9 +14,8 @@ def world_with_mutant_on_start(tmp_path):
     persistence.SAVE_PATH = tmp_path / ".mutants2" / "save.json"
     os.environ["HOME"] = str(tmp_path)
     p = Player()
-    w = World(
-        monsters={(2000, 0, 0): [{"key": "mutant", "hp": 3}]}, seeded_years={2000}
-    )
+    w = World(seeded_years={2000})
+    w.place_monster(2000, 0, 0, "mutant")
     save = persistence.Save()
     persistence.save(p, w, save)
     return None


### PR DESCRIPTION
## Summary
- broaden `ItemInstance` typing and rewrite `coerce_item`
- add new +1 gear items and five geared monster kinds with seeding logic
- show monster level on look and drop wielded/worn gear on death

## Testing
- `pre-commit run --files mutants2/cli/shell.py mutants2/engine/items.py mutants2/engine/items_util.py mutants2/engine/monsters.py mutants2/engine/player.py mutants2/engine/world.py mutants2/types.py mutants2/ui/items_render.py tests/smoke/test_bug_skin_add_convert_look.py tests/smoke/test_equip_render_rewards.py tests/test_combat_minimal.py` *(failed: missing python3.11 runtime)*
- `pytest` *(failed: 18 failed, 197 passed)*
- `pyright mutants2 --level warning`

------
https://chatgpt.com/codex/tasks/task_e_68bd80a3e828832b9aa1e9721e039997