### PR TITLE
breaking: repo cleanup & schema hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,11 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - run: pip install -e '.[dev]'
-      - run: pytest -q tests/smoke
+      - run: black --check .
+      - run: ruff .
+      - run: pyright mutants2 --level error
+      - run: vulture mutants2
+      - run: pytest -q tests/smoke --cov=mutants2 --cov-report=term
 
   full:
     if: github.event_name != 'pull_request'
@@ -29,5 +33,8 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - run: pip install -e '.[dev]'
-      - run: pytest -q
-      - run: pyright mutants2 --level warning
+      - run: black --check .
+      - run: ruff .
+      - run: pyright mutants2 --level error
+      - run: vulture mutants2
+      - run: pytest -q --cov=mutants2 --cov-report=term --cov-fail-under=85

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,13 @@ repos:
     hooks:
       - id: black
         language_version: python3.11
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.351
+    hooks:
+      - id: pyright
+        additional_dependencies: []
+  - repo: https://github.com/jendrikseipp/vulture
+    rev: v2.7
+    hooks:
+      - id: vulture
+        args: ["mutants2"]

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 A tiny text adventure with a deterministic 30x30 map. The game currently only
 supports the year 2000 and a single player wandering a maze.
 
+> **Breaking change**: existing saves from earlier versions are no longer
+> compatible.  The engine now enforces a strict save schema and will refuse to
+> load unknown versions.  Use `debug reset` to remove the on-disk save file or
+> `debug wipe` while in a session to clear in-memory state.
+
 ## Running
 
 ```bash

--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 import datetime
 import time
-from typing import Mapping, MutableMapping, cast
+from typing import Mapping, cast
 
 from ..engine import persistence, items, monsters, combat
 from ..engine.items_resolver import (
@@ -243,7 +243,6 @@ def make_context(p, w, save, *, dev: bool = False):
     macro_store.load_profile(class_key(p.clazz or "default"))
     last_move = None
 
-
     context = SimpleNamespace(
         macro_store=macro_store,
         running=True,
@@ -448,7 +447,9 @@ def make_context(p, w, save, *, dev: bool = False):
         if p.worn_armor:
             old_inst = coerce_item(p.worn_armor)
             old_def = get_item_def_by_key(old_inst["key"])
-            print(yellow(f"You remove the {display_item_name_plain(old_inst, old_def)}."))
+            print(
+                yellow(f"You remove the {display_item_name_plain(old_inst, old_def)}.")
+            )
         p.worn_armor = inst_match
         p.recompute_ac()
         print(yellow(f"You wear the {display_item_name_plain(inst_match, idef)}."))
@@ -508,9 +509,7 @@ def make_context(p, w, save, *, dev: bool = False):
         p.wielded_weapon = inst_match
         mon = w.monster_here(p.year, p.x, p.y)
         ready = (
-            p.ready_to_combat_id
-            and mon
-            and str(mon.get("id")) == p.ready_to_combat_id
+            p.ready_to_combat_id and mon and str(mon.get("id")) == p.ready_to_combat_id
         )
         if not ready:
             print(yellow("***"))
@@ -829,6 +828,8 @@ def make_context(p, w, save, *, dev: bool = False):
   debug today YYYY-MM-DD              Set synthetic 'today' (dev date).
   debug today clear                   Clear synthetic date.
   debug topup                         Run daily item top-up now.
+  debug reset                         Delete on-disk save data.
+  debug wipe                          Clear in-memory profiles and world.
   macro keys debug on|off             Toggle macro key debug (if available).
 """
                 )
@@ -847,7 +848,13 @@ def make_context(p, w, save, *, dev: bool = False):
             if not dev:
                 print("Debug commands are available only in dev mode.")
             else:
-                if args[:2] == ["item", "add"] and len(args) >= 3:
+                if args[:1] == ["reset"]:
+                    persistence.debug_reset()
+                    print("Save data removed.")
+                elif args[:1] == ["wipe"]:
+                    persistence.debug_wipe(p, w, save)
+                    print("In-memory state cleared.")
+                elif args[:2] == ["item", "add"] and len(args) >= 3:
                     name_or_key = args[2]
                     extra = args[3:]
                     count = 1

--- a/mutants2/engine/persistence.py
+++ b/mutants2/engine/persistence.py
@@ -5,7 +5,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, Set, Tuple, Any
+from typing import Any, Dict, Set, Tuple
 
 from .player import Player, class_key
 from .world import World
@@ -23,7 +23,9 @@ from .items_util import coerce_item
 from .macros import MacroStore
 
 from . import gen
-from ..data.class_tables import BASE_LEVEL1, PROGRESSION
+
+
+SAVE_SCHEMA = 3
 
 
 @dataclass
@@ -39,20 +41,9 @@ class Save:
     last_upkeep_tick: float = field(default_factory=lambda: time.monotonic())
     next_upkeep_tick: float | None = None  # monotonic deadline for next 10s tick
     max_catchup_ticks: int = 6
-    schema_version: int = 2
 
 
 SAVE_PATH = Path(os.path.expanduser("~/.mutants2/save.json"))
-
-
-_ATTR_MAP = {
-    "str": "strength",
-    "int": "intelligence",
-    "wis": "wisdom",
-    "dex": "dexterity",
-    "con": "constitution",
-    "cha": "charisma",
-}
 
 
 def _serialize_item(val: ItemInstance | str) -> dict[str, Any]:
@@ -62,26 +53,6 @@ def _serialize_item(val: ItemInstance | str) -> dict[str, Any]:
 
 def _deserialize_item(val: Any) -> ItemInstance:
     return coerce_item(val)
-
-
-def _migrate_profile(clazz: str, prof: CharacterProfile) -> None:
-    if getattr(prof, "tables_migrated", False):
-        return
-    base = BASE_LEVEL1[clazz]
-    for key, attr in _ATTR_MAP.items():
-        setattr(prof, attr, base[key])
-    prof.max_hp = base["hp"]
-    prof.ac = base["ac"]
-    for lvl in range(2, prof.level + 1):
-        row = PROGRESSION[clazz].get(lvl, PROGRESSION[clazz][11])
-        prof.max_hp += row.get("hp_plus", 0)
-        for short, attr in _ATTR_MAP.items():
-            setattr(prof, attr, getattr(prof, attr) + row.get(f"{short}_plus", 0))
-    if prof.hp > prof.max_hp:
-        prof.hp = prof.max_hp
-    prof.natural_dex_ac = prof.dexterity // 10
-    prof.ac_total = prof.ac + prof.natural_dex_ac
-    prof.tables_migrated = True
 
 
 def load() -> tuple[
@@ -94,6 +65,10 @@ def load() -> tuple[
     try:
         with open(SAVE_PATH) as fh:
             data = json.load(fh)
+        if data.get("schema") != SAVE_SCHEMA:
+            raise RuntimeError(
+                "Save is from an older version and is not supported; please start a new game."
+            )
         data.pop("walls", None)
         data.pop("blocked", None)
 
@@ -102,7 +77,6 @@ def load() -> tuple[
         if isinstance(profiles_raw, dict):
             for k, v in profiles_raw.items():
                 prof = profile_from_raw(v)
-                _migrate_profile(class_key(k), prof)
                 profiles[class_key(k)] = prof
 
         last_class_raw = data.get("last_class")
@@ -120,7 +94,6 @@ def load() -> tuple[
 
         if active_class:
             prof = profiles[active_class]
-            _migrate_profile(active_class, prof)
             player = Player(year=prof.year, clazz=active_class)
             apply_profile(player, prof)
         else:
@@ -155,7 +128,6 @@ def load() -> tuple[
             player.ready_to_combat_id = data.get("ready_to_combat_id")
             player.ready_to_combat_name = data.get("ready_to_combat_name")
             prof = profile_from_player(player)
-            _migrate_profile(clazz, prof)
             apply_profile(player, prof)
             profiles[clazz] = prof
             last_class = clazz
@@ -197,7 +169,9 @@ def load() -> tuple[
                 name = entry.get("name")
                 aggro = entry.get("aggro", False)
                 seen = entry.get("seen", False)
-                has_yelled = entry.get("yelled_once") or entry.get("has_yelled_this_aggro", False)
+                has_yelled = entry.get("yelled_once") or entry.get(
+                    "has_yelled_this_aggro", False
+                )
                 mid = entry.get("id")
                 loot_i = entry.get("loot_ions", 0)
                 loot_r = entry.get("loot_riblets", 0)
@@ -233,37 +207,17 @@ def load() -> tuple[
             profiles=profiles,
             last_upkeep_tick=time.monotonic() - max(0.0, now_wall - last_wall),
             max_catchup_ticks=int(data.get("max_catchup_ticks", 6)),
-            schema_version=int(data.get("schema_version", 1)),
         )
-
-        from .items_resolver import resolve_key
-
-        def _migrate_list(lst):
-            out = []
-            for it in lst:
-                inst = coerce_item(it)
-                inst["key"] = resolve_key(inst["key"])
-                out.append(inst)
-            return out
-
-        player.inventory = _migrate_list(player.inventory)
-        if player.worn_armor is not None:
-            player.worn_armor = coerce_item(player.worn_armor)
-            player.worn_armor["key"] = resolve_key(player.worn_armor["key"])
-        for k, items in ground.items():
-            ground[k] = _migrate_list(items)
-
-        migrated = False
-        if save_meta.schema_version < 2:
-            save_meta.schema_version = 2
-            migrated = True
-
-        needs_save = migrated or (not active_class and profiles)
+        needs_save = not active_class and profiles
         if needs_save:
             save(
                 player,
                 World(
-                    ground, seeded, monsters_data, seed_monsters=False, global_seed=save_meta.global_seed
+                    ground,
+                    seeded,
+                    monsters_data,
+                    seed_monsters=False,
+                    global_seed=save_meta.global_seed,
                 ),
                 save_meta,
             )
@@ -278,7 +232,11 @@ def load() -> tuple[
         save(
             player,
             World(
-                ground, seeded, monsters_data, seed_monsters=False, global_seed=save_meta.global_seed
+                ground,
+                seeded,
+                monsters_data,
+                seed_monsters=False,
+                global_seed=save_meta.global_seed,
             ),
             save_meta,
         )
@@ -354,7 +312,27 @@ def save(player: Player, world: World, save_meta: Save) -> None:
             "seeded_years": list(world.seeded_years),
             "global_seed": save_meta.global_seed,
             "last_topup_date": save_meta.last_topup_date,
-            "schema_version": save_meta.schema_version,
+            "schema": SAVE_SCHEMA,
             # no senses data; cues are never persisted
         }
         json.dump(data, fh)
+
+
+def debug_reset() -> None:
+    """Remove the on-disk save file, if present."""
+
+    try:
+        SAVE_PATH.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def debug_wipe(player: Player, world: World, save_meta: Save) -> None:
+    """Clear in-memory state such as profiles, monsters and ground items."""
+
+    world.ground.clear()
+    world.monsters.clear()
+    world.seeded_years.clear()
+    save_meta.profiles.clear()
+    save_meta.last_class = None
+    player.inventory.clear()

--- a/mutants2/types.py
+++ b/mutants2/types.py
@@ -1,11 +1,56 @@
-from typing import TypedDict, Tuple, Sequence, Mapping, Any, Required
+"""Canonical TypedDict schemas used across the project.
+
+The goal of this module is to provide a single source of truth for the
+structures persisted to disk or exchanged between internal modules. The
+schemas deliberately keep the number of fields to a minimum and avoid any
+legacy aliases or optional behaviour. Public APIs should use ``Mapping`` or
+``Sequence`` when consuming these types while the engine may mutate the
+underlying ``dict``/``list`` instances as needed.
+"""
+
+from __future__ import annotations
+
+from typing import NotRequired, TypedDict, Tuple
 
 TileKey = Tuple[int, int, int]
 
 
 class ItemInstance(TypedDict, total=False):
-    key: Required[str]
-    enchant: int | None
-    base_power: int | None
-    ac_bonus: int | None
-    meta: dict[str, Any]
+    """A concrete item in the world or inventory."""
+
+    # Canonical registry key (hyphenated)
+    key: str
+    enchant: NotRequired[int]
+    base_power: NotRequired[int]
+    ac_bonus: NotRequired[int]
+    weight_lbs: NotRequired[int]
+
+
+class MonsterInstance(TypedDict, total=False):
+    """Serialized monster instance."""
+
+    kind: str  # canonical monster key
+    id: str  # stable per-entity id for suffix
+    pos: TileKey
+    aggro: bool
+    seen: bool
+    yelled_once: NotRequired[bool]
+    level: int
+    STR: int
+    INT: int
+    WIS: int
+    DEX: int
+    CON: int
+    CHA: int
+    worn_armor: NotRequired[ItemInstance]
+    wielded_weapon: NotRequired[ItemInstance]
+    inventory: NotRequired[list[ItemInstance]]
+
+
+class SaveDoc(TypedDict, total=False):
+    """Minimal save file structure written to disk."""
+
+    schema: int
+    global_seed: int
+    last_topup_date: str
+    # add minimal, explicit fields only

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dev = [
   "ruff",
   "mypy",
   "pyright",
+  "pytest-cov",
+  "vulture",
 ]
 
 [tool.black]
@@ -30,4 +32,18 @@ target-version = ["py311"]
 [tool.ruff]
 line-length = 88
 target-version = "py311"
+
+[tool.pyright]
+include = ["mutants2"]
+exclude = ["tests"]
+pythonVersion = "3.11"
+typeCheckingMode = "strict"
+
+[tool.coverage.run]
+branch = true
+source = ["mutants2"]
+
+[tool.coverage.report]
+fail_under = 85
+show_missing = true
 

--- a/scripts/scan_cleanup.py
+++ b/scripts/scan_cleanup.py
@@ -1,0 +1,35 @@
+"""Simple cleanup scan helper.
+
+This script is a lightweight aid for developers to quickly locate common
+issues when performing repository maintenance.  It intentionally avoids
+performing any writes; it merely prints findings to stdout.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def run(cmd: list[str]) -> None:
+    print("$", " ".join(cmd))
+    subprocess.run(cmd, check=False)
+
+
+def main() -> None:
+    run(["ruff", "--select", "F401,F841", str(ROOT / "mutants2")])
+    run(
+        [
+            "rg",
+            "bug_skin_armour|attack|old travel",
+            str(ROOT / "mutants2"),
+        ]
+    )
+    run(["rg", "print\(", str(ROOT / "mutants2" / "engine")])
+    run(["rg", ",", str(ROOT / "mutants2")])
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def cli_runner(tmp_path):
             cmd = [sys.executable, "-m", "mutants2"]
             env = os.environ.copy()
             env["HOME"] = str(tmp_path)
-            persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
+            persistence.SAVE_PATH = tmp_path / ".mutants2" / "save.json"
             save_path = persistence.SAVE_PATH
             if save_path.exists():
                 with open(save_path) as fh:
@@ -41,6 +41,7 @@ def cli_runner(tmp_path):
                         "riblets": data.get("riblets", 0),
                     }
                 data["last_class"] = "Warrior"
+                data["schema"] = persistence.SAVE_SCHEMA
                 with open(save_path, "w") as fh:
                     json.dump(data, fh)
             else:
@@ -51,7 +52,9 @@ def cli_runner(tmp_path):
                 save.last_class = "Warrior"
                 save.profiles["Warrior"] = {
                     "year": p.year,
-                    "positions": {str(y): {"x": x, "y": yy} for y, (x, yy) in p.positions.items()},
+                    "positions": {
+                        str(y): {"x": x, "y": yy} for y, (x, yy) in p.positions.items()
+                    },
                     "hp": p.hp,
                     "max_hp": p.max_hp,
                     "inventory": [],
@@ -60,7 +63,9 @@ def cli_runner(tmp_path):
                 }
                 persistence.save(p, w, save)
             inp = "\n".join(commands + ["exit"]) + "\n"
-            result = subprocess.run(cmd, input=inp, text=True, capture_output=True, env=env)
+            result = subprocess.run(
+                cmd, input=inp, text=True, capture_output=True, env=env
+            )
             return result.stdout
 
     return Runner()

--- a/tests/test_debug_reset_wipe.py
+++ b/tests/test_debug_reset_wipe.py
@@ -1,0 +1,24 @@
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+
+
+def test_debug_reset(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    persistence.SAVE_PATH = tmp_path / "save.json"
+    w = world_mod.World()
+    p = Player()
+    save = persistence.Save()
+    persistence.save(p, w, save)
+    assert persistence.SAVE_PATH.exists()
+    persistence.debug_reset()
+    assert not persistence.SAVE_PATH.exists()
+
+
+def test_debug_wipe():
+    w = world_mod.World()
+    w.ground[(2000, 0, 0)] = [{"key": "test-item"}]
+    p = Player()
+    save = persistence.Save(profiles={"Warrior": {}})
+    persistence.debug_wipe(p, w, save)
+    assert w.ground == {}
+    assert save.profiles == {}

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,16 +1,20 @@
+import json
+
+import pytest
+
 from mutants2.engine.world import World
 from mutants2.engine.player import Player
 from mutants2.engine import persistence
 
 
 def test_save_load(tmp_path, monkeypatch):
-    monkeypatch.setenv('HOME', str(tmp_path))
-    persistence.SAVE_PATH = tmp_path / '.mutants2' / 'save.json'
+    monkeypatch.setenv("HOME", str(tmp_path))
+    persistence.SAVE_PATH = tmp_path / ".mutants2" / "save.json"
     w = World()
     p = Player()
-    assert p.move('east', w)
+    assert p.move("east", w)
     p.travel(w, 2100)
-    assert p.move('north', w)
+    assert p.move("north", w)
     save = persistence.Save()
     persistence.save(p, w, save)
     p2, ground, monsters, seeded, _ = persistence.load()
@@ -18,3 +22,13 @@ def test_save_load(tmp_path, monkeypatch):
     w2 = World(ground, seeded, monsters)
     p2.travel(w2, 2000)
     assert (p2.x, p2.y) == (0, 0)
+
+
+def test_old_schema_refused(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    persistence.SAVE_PATH = tmp_path / ".mutants2" / "save.json"
+    persistence.SAVE_PATH.parent.mkdir(parents=True)
+    with open(persistence.SAVE_PATH, "w") as fh:
+        json.dump({"schema": 1}, fh)
+    with pytest.raises(RuntimeError):
+        persistence.load()


### PR DESCRIPTION
## Summary
- define canonical TypedDict schemas for items, monsters and save files
- hard fail loading mismatched SAVE_SCHEMA and expose debug reset/wipe hooks
- wire reset/wipe through CLI and document the breaking save reset
- tighten CI and pre-commit with format, lint, type check, dead code and coverage gates
- add tests to ensure old saves are rejected and debug utilities work

## Testing
- `black --check mutants2/types.py mutants2/engine/persistence.py mutants2/cli/shell.py tests/conftest.py tests/test_persistence.py tests/test_debug_reset_wipe.py tests/test_progression_tables.py scripts/scan_cleanup.py`  
- `ruff check mutants2/types.py mutants2/engine/persistence.py mutants2/cli/shell.py tests/conftest.py tests/test_persistence.py tests/test_debug_reset_wipe.py tests/test_progression_tables.py scripts/scan_cleanup.py`  
- `pyright mutants2` *(fails: numerous unknown-type errors in existing modules)*  
- `vulture mutants2` *(reports several unused functions and variables)*  
- `pytest tests/test_persistence.py tests/test_debug_reset_wipe.py tests/test_progression_tables.py::test_old_saves_rejected -q`  
- `pytest -q --cov=mutants2 --cov-report=term` *(fails: coverage 77% < required 85%)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd010450c832bbafe8f80daaece2f