### PR TITLE
Remove empty inventory placeholder and guard wielding worn items

### DIFF
--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -505,6 +505,12 @@ def make_context(p, w, save, *, dev: bool = False):
             context._needs_render = False
             context._suppress_room_render = True
             return False
+        if p.worn_armor is inst_match:
+            print(yellow("***"))
+            print(yellow("You cannot wield something you are wearing."))
+            context._needs_render = False
+            context._suppress_room_render = True
+            return False
         idef = get_item_def_by_key(key)
         p.wielded_weapon = inst_match
         mon = w.monster_here(p.year, p.x, p.y)
@@ -716,8 +722,6 @@ def make_context(p, w, save, *, dev: bool = False):
             labels = enumerate_duplicates(names)
             wrapped = wrap_list_ansi(labels)
             lines.extend(white(ln) for ln in wrapped.splitlines())
-        else:
-            lines.append("(empty)")
         for ln in lines:
             print(ln)
 
@@ -769,8 +773,6 @@ def make_context(p, w, save, *, dev: bool = False):
                 wrapped = wrap_list_ansi(labels)
                 for ln in wrapped.splitlines():
                     print(white(ln))
-            else:
-                print("(empty)")
             context._needs_render = False
             context._suppress_room_render = True
         elif cmd == "get":

--- a/tests/smoke/test_travel_convert_and_items.py
+++ b/tests/smoke/test_travel_convert_and_items.py
@@ -23,7 +23,7 @@ def test_monster_bait_conversion(cli_runner, tmp_path):
     assert item.ion_value == 10000
     assert yellow("The Monster-Bait vanishes with a flash!") in out
     assert yellow("You convert the Monster-Bait into 10000 ions.") in out
-    assert "(empty)" in out
+    assert "(empty)" not in out
     assert "Ions         : 10000" in out
 
 

--- a/tests/smoke/test_wear_wield_damage.py
+++ b/tests/smoke/test_wear_wield_damage.py
@@ -94,3 +94,26 @@ def test_wield_attack_damage():
     assert re.search(pattern, out)
     assert "Ready to Combat: NO ONE" in out
     assert w.monster_here(2000, 0, 0) is None
+
+
+def test_cannot_wield_worn_item():
+    def setup(w, p):
+        w.add_ground_item(2000, 0, 0, "bug-skin")
+
+    out, _, _ = run_commands(["get bug", "wear bug", "wield bug"], setup=setup)
+    assert "You cannot wield something you are wearing." in out
+    assert "You're not ready to combat anyone." not in out
+
+
+def test_wield_armor_when_not_worn():
+    def setup(w, p):
+        w.add_ground_item(2000, 0, 0, "bug-skin")
+        w.place_monster(2000, 0, 0, "mutant")
+
+    out, w, p = run_commands(
+        ["get bug", "combat mutant", "wield bug", "status"], setup=setup
+    )
+    assert "You wield the Bug-Skin." in out
+    expected = items.REGISTRY["bug-skin"].base_power + p.strength // 10
+    pattern = rf"You hit Mutant-\d{{4}} for {expected} damage\.  \(temp\)"
+    assert re.search(pattern, out)

--- a/tests/test_commands_abbrev.py
+++ b/tests/test_commands_abbrev.py
@@ -37,7 +37,7 @@ def test_three_letter_abbrevs(cli_runner):
 
 def test_inventory_aliases(cli_runner):
     out = cli_runner.run_commands(["inv"])
-    assert "(empty)" in out or "Inventory" in out
+    assert "(empty)" not in out
     out = cli_runner.run_commands(["i"])
     assert yellow("You're iing!") in out
 

--- a/tests/test_convert_command.py
+++ b/tests/test_convert_command.py
@@ -27,5 +27,5 @@ def test_convert_bottle_cap(cli_runner, inventory_with_cap):
     assert out.count("***") == 2
     assert yellow("The Bottle-Cap vanishes with a flash!") in out
     assert yellow("You convert the Bottle-Cap into 22000 ions.") in out
-    assert "(empty)" in out
+    assert "(empty)" not in out
     assert "Ions         : 22000" in out

--- a/tests/test_items_basic.py
+++ b/tests/test_items_basic.py
@@ -97,7 +97,7 @@ def test_pickup_and_drop_roundtrip(tmp_path):
     assert "You drop Ion-Decay." in out
     after = out.split("You drop Ion-Decay.")[-1]
     assert "On the ground lies:" in after and "Ion-Decay" in after
-    assert "(empty)" in after
+    assert "(empty)" not in after
 
 
 def test_inventory_rendering(tmp_path):

--- a/tests/test_skull_item.py
+++ b/tests/test_skull_item.py
@@ -32,5 +32,5 @@ def test_skull_look_and_convert(tmp_path):
         ctx.dispatch_line("status")
     out = strip_ansi(buf.getvalue())
     assert "You convert the Skull into 25000 ions." in out
-    assert "(empty)" in out
+    assert "(empty)" not in out
     assert "Ions         : 25000" in out


### PR DESCRIPTION
## Summary
- stop showing `(empty)` in inventory and status screens
- prevent wielding items that are currently worn while still allowing unworn armor
- add tests verifying armor wielding and worn-item restrictions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bde051a3dc832b86a7514dbebeab58