### PR TITLE
Fix not-carrying message and correct natural AC calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ pytest
 
 - Save schema bumped to `6`. Older saves are discarded on load and a fresh
   world is seeded automatically.
-- Natural armour from Dexterity is now `1 + (DEX // 10)` and stacks with worn
-  armour.
+- Natural armour from Dexterity is `DEX // 10` and stacks with worn armour.
 - Worn items are no longer counted in inventory; only `remove` operates on worn
   armour.
 - `look <item>` only works for items in your inventory. Looking for an item on

--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -49,7 +49,7 @@ from ..engine.macros import MacroStore
 from ..engine.types import Direction
 from ..engine.world import ALLOWED_CENTURIES, LOWEST_CENTURY, HIGHEST_CENTURY
 from ..ui.help import MACROS_HELP, ABBREVIATIONS_NOTE, COMMANDS_HELP, USAGE
-from ..ui.strings import GET_WHAT, DROP_WHAT, NOT_CARRYING, CANT_SEE
+from ..ui.strings import GET_WHAT, DROP_WHAT, not_carrying, CANT_SEE
 from ..ui.theme import red, SEP, yellow, white
 from ..data.config import ION_TRAVEL_COST, HEAL_K
 from ..ui.render import (
@@ -386,14 +386,7 @@ def make_context(p, w, save, *, dev: bool = False):
         raw = " ".join(args)
         obj = resolve_item(raw, "inventory", p, w)
         if obj is None:
-            name = raw
-            worn_inst = resolve_item(raw, "worn", p, w)
-            if worn_inst is not None:
-                inst_w = coerce_item(worn_inst)
-                idef_w = get_item_def_by_key(resolve_key(inst_w["key"]))
-                name = display_item_name_plain(inst_w, idef_w)
-            print(yellow("***"))
-            print(yellow(NOT_CARRYING.format(name)))
+            print(not_carrying(raw))
             context._needs_render = False
             context._suppress_room_render = True
             return False
@@ -423,14 +416,7 @@ def make_context(p, w, save, *, dev: bool = False):
         raw = " ".join(args)
         obj = resolve_item(raw, "inventory", p, w)
         if obj is None:
-            name = raw
-            worn_inst = resolve_item(raw, "worn", p, w)
-            if worn_inst is not None:
-                inst_w = coerce_item(worn_inst)
-                idef_w = get_item_def_by_key(resolve_key(inst_w["key"]))
-                name = display_item_name_plain(inst_w, idef_w)
-            print(yellow("***"))
-            print(yellow(NOT_CARRYING.format(name)))
+            print(not_carrying(raw))
             context._needs_render = False
             context._suppress_room_render = True
             return False
@@ -497,14 +483,7 @@ def make_context(p, w, save, *, dev: bool = False):
         raw = " ".join(args)
         obj = resolve_item(raw, "inventory", p, w)
         if obj is None:
-            name = raw
-            worn_inst = resolve_item(raw, "worn", p, w)
-            if worn_inst is not None:
-                inst_w = coerce_item(worn_inst)
-                idef_w = get_item_def_by_key(resolve_key(inst_w["key"]))
-                name = display_item_name_plain(inst_w, idef_w)
-            print(yellow("***"))
-            print(yellow(NOT_CARRYING.format(name)))
+            print(not_carrying(raw))
             context._needs_render = False
             context._suppress_room_render = True
             return False
@@ -540,14 +519,7 @@ def make_context(p, w, save, *, dev: bool = False):
         raw = " ".join(args)
         obj = resolve_item(raw, "inventory", p, w)
         if obj is None:
-            name = raw
-            worn_inst = resolve_item(raw, "worn", p, w)
-            if worn_inst is not None:
-                inst_w = coerce_item(worn_inst)
-                idef_w = get_item_def_by_key(resolve_key(inst_w["key"]))
-                name = display_item_name_plain(inst_w, idef_w)
-            print(yellow("***"))
-            print(yellow(NOT_CARRYING.format(name)))
+            print(not_carrying(raw))
             context._needs_render = False
             context._suppress_room_render = True
             return False

--- a/mutants2/engine/player.py
+++ b/mutants2/engine/player.py
@@ -75,7 +75,7 @@ class Player:
 
     def recompute_ac(self) -> None:
         """Recompute natural and total armour class."""
-        self.natural_dex_ac = 1 + (self.dexterity // 10)
+        self.natural_dex_ac = self.dexterity // 10
         worn_bonus = 0
         if self.worn_armor:
             key = (

--- a/mutants2/engine/state.py
+++ b/mutants2/engine/state.py
@@ -95,7 +95,7 @@ def apply_profile(p: "Player", prof: CharacterProfile) -> None:
     p.dexterity = getattr(prof, "dexterity", 0)
     p.constitution = getattr(prof, "constitution", 0)
     p.charisma = getattr(prof, "charisma", 0)
-    p.natural_dex_ac = getattr(prof, "natural_dex_ac", 1 + p.dexterity // 10)
+    p.natural_dex_ac = getattr(prof, "natural_dex_ac", p.dexterity // 10)
     p.ac_total = getattr(prof, "ac_total", p.natural_dex_ac)
     p.ready_to_combat_id = getattr(prof, "ready_to_combat_id", None)
     p.ready_to_combat_name = getattr(prof, "ready_to_combat_name", None)

--- a/mutants2/ui/strings.py
+++ b/mutants2/ui/strings.py
@@ -1,5 +1,16 @@
+from .theme import yellow
+
 GET_WHAT = "What do you want to get?"
 DROP_WHAT = "What do you want to drop?"
 NOT_ENOUGH_IONS_PORTAL = "You don't have enough ions to create a portal."
-NOT_CARRYING = "You're not carrying a {0}."
 CANT_SEE = "You can't see {0}."
+
+
+def not_carrying(raw: str) -> str:
+    """Return the yellow not-carrying message for ``raw``.
+
+    ``raw`` is the exact subject as typed by the user with surrounding
+    whitespace trimmed.
+    """
+
+    return yellow(f"You're not carrying {raw}.")

--- a/tests/smoke/test_bug_skin_add_convert_look.py
+++ b/tests/smoke/test_bug_skin_add_convert_look.py
@@ -77,7 +77,7 @@ def test_convert_worn_bug_skin(tmp_path):
         ],
         tmp_path / "worn",
     )
-    assert yellow("You're not carrying a Bug-Skin.") in out
+    assert yellow("You're not carrying bug.") in out
     assert "vanishes with a flash" not in out
     assert p.ions == 0
     assert p.worn_armor is not None

--- a/tests/smoke/test_travel_convert_and_items.py
+++ b/tests/smoke/test_travel_convert_and_items.py
@@ -29,8 +29,7 @@ def test_monster_bait_conversion(cli_runner, tmp_path):
 
 def test_convert_gibberish(cli_runner):
     out = cli_runner.run_commands(["con asd"])
-    assert yellow("***") in out
-    assert yellow("You're not carrying a asd.") in out
+    assert yellow("You're not carrying asd.") in out
 
 
 def test_travel_rounding_and_stats(cli_runner):

--- a/tests/smoke/test_wear_wield_damage.py
+++ b/tests/smoke/test_wear_wield_damage.py
@@ -102,7 +102,7 @@ def test_cannot_wield_worn_item():
         w.add_ground_item(2000, 0, 0, "bug-skin")
 
     out, _, _ = run_commands(["get bug", "wear bug", "wield bug"], setup=setup)
-    assert "You're not carrying a Bug-Skin." in out
+    assert "You're not carrying bug." in out
     assert "You cannot wield" not in out
     assert "You're not ready to combat anyone." not in out
 
@@ -131,7 +131,7 @@ def test_inventory_commands_ignore_worn():
         ["get bug", "wear bug", "drop bug", "convert bug", "wield bug"],
         setup=setup,
     )
-    assert out.count("You're not carrying a Bug-Skin.") == 3
+    assert out.count("You're not carrying bug.") == 3
     assert "You are here." not in out and "Compass:" not in out
     assert p.worn_armor is not None
 

--- a/tests/test_natural_dex_ac.py
+++ b/tests/test_natural_dex_ac.py
@@ -6,7 +6,7 @@ from mutants2.engine.items import ItemDef
 
 
 def test_natural_dex_ac_values():
-    cases = {9: 1, 10: 2, 19: 2, 20: 3, 29: 3, 30: 4}
+    cases = {9: 0, 10: 1, 19: 1, 20: 2, 29: 2, 30: 3}
     for dex, expected in cases.items():
         p = Player()
         p.dexterity = dex
@@ -31,13 +31,13 @@ def test_ac_total_with_armor():
 @pytest.mark.parametrize("clazz", list(BASE_LEVEL1.keys()))
 def test_classes_starting_ac(clazz):
     p = Player(clazz=clazz)
-    assert p.ac_total == 1 + (p.dexterity // 10)
+    assert p.ac_total == p.dexterity // 10
 
 
 def test_ac_totals_with_bonus_seven():
     temp = ItemDef("temp_arm", "Temp-Arm", 0, None, None, False, None, 0, 7, 0, None)
     items.REGISTRY["temp_arm"] = temp
-    for dex, total in zip([0, 10, 20, 30, 40], [8, 9, 10, 11, 12]):
+    for dex, total in zip([9, 10, 19, 20, 29, 30], [7, 8, 8, 9, 9, 10]):
         p = Player()
         p.dexterity = dex
         p.worn_armor = {"key": "temp_arm"}


### PR DESCRIPTION
## Summary
- show `You're not carrying <item>` using the exact subject typed
- compute natural Dexterity armour class as `DEX // 10` and recompute totals
- update tests and docs for new AC table

## Testing
- `black .`
- `ruff .` *(fails: unrecognized subcommand `.`)*
- `ruff check .`
- `pyright` *(fails: 73 errors)*
- `vulture .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bec2484c80832badf4ca1b42669415