### PR TITLE
feat: enforce travel render gating and update docs

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,8 +1,59 @@
-# Agents
+# Mutants2 — Agents & Single Source of Truth
 
-- Run `black .`, `ruff .`, `pyright`, `vulture`, and `pytest` before submitting changes.
-- Use canonical item keys (lowercase with underscores) in code and tests.
-- Breaking changes require bumping `SAVE_SCHEMA` and start a fresh world; do not write migrations.
-- Item names in code remain plain; enchantment is revealed via `look`.
-- The world is deterministically seeded only via the CLI; tests must use a temporary save path.
-- Worn items are not part of inventory; use `resolve_item(prefix, scope)` for item lookups.
+This document defines the contracts our agents (and humans) must follow.  
+**CI gates:** run `black .`, `ruff .`, `pyright`, `vulture`, and `pytest` before submitting changes.
+
+## Guardrails (always on)
+- **Canonical keys:** Use lowercase underscore keys in code/tests (e.g., `nuclear_rock`, `bug_skin`).
+- **Breaking changes:** Bump `SAVE_SCHEMA` and start a fresh world; **do not write migrations**.
+- **Determinism:** The world is deterministically seeded **only in the CLI entrypoint**; tests must use a **temporary SAVE_PATH** and opt-in seeding.
+- **Worn ≠ inventory:** Worn items are not in inventory scope; use helpers like `resolve_item(prefix, scope="inventory"|"worn")`.
+
+## Core world & movement
+- Each century is a **30×30** grid; edges block; center is **(0E : 0N)**.
+- **Centuries enabled:** **2000–3000** inclusive, in 100-year steps.
+- `travel <year>` lands at that century’s **center**; non-century input **rounds down** to the nearest in-range century and prints:  
+  **`ZAAAAPPPPP!! You've been sent to the year {CENTURY} A.D.`**  
+  If out-of-range, print the bounds message (“You can only travel from year 2000 to {max_century}!”).
+- **Render gating:** **Movement re-renders; travel does not; `look` (no args) re-renders.**
+
+## Input, targets, and UI
+- Commands: **3..full** prefixes; `look <dir>`: **1..full**; item/monster targets: **1..full**; **first match wins**.
+- Inventory/Status show **plain names** (no “+N”); enchantment is revealed via `look`.
+- Numbers have **no commas**; use a global **A/An** article helper for messages.
+
+## Look semantics
+- `look` (no args): on-tile peek that can trigger aggro checks.
+- `look <item>` searches **inventory only**.  
+  – If found and spawnable: print yellow **“It looks like a lovely <Title-Case Item-Name>!”**.  
+  – If not in inventory (on ground or worn): print yellow using the raw token: **“You can't see `<raw_subject>`.”**  
+- `look <dir>` peeks without shadows.
+
+## Aggro, footsteps, arrivals
+- Monsters spawn **passive**; on room entry or `look` (no args) on a shared tile: **50/50** to aggro; on success, yell once: **“<Name> yells at you!”**.
+- Only **aggro** monsters move one step after the player turn; if none aggro in-year, **skip** the movement tick.  
+- **Footsteps:** loud at **2**, faint at **3–6**, none at **<1**; supports intermediate directions (e.g., “south-west”).  
+- In an arrival tick, render **arrivals (red) last** and **suppress** the generic presence line.
+
+## Monsters, targeting, and rewards
+- Multiple monsters can share a tile; names include a **unique 4-digit suffix** (e.g., `Mutant-1846`).
+- **`combat <monster>`** selects a target (consumes a turn) and prints yellow **“You’re ready to combat <Name>!”**; legacy `attack` is removed.
+- Wielding hits only if **ready to combat** someone.  
+- On kill: award **20000 riblets** and **20000 ions**.
+
+## Inventory vs worn vs wield
+- **Worn items are not inventory:** `drop/convert/wield/wear` **exclude worn**; only **`remove`** acts on worn.
+- If both worn and carried copies exist, commands act on the **carried** copy.
+
+## Armour Class (AC)
+- **Natural AC from DEX:** `natural_dex_ac = 1 + floor(DEX/10)` (0–9→1, 10–19→2, 20–29→3, 30–39→4, …).
+- **Total AC** = `natural_dex_ac + worn_armor_ac` and is recomputed on wear/remove, level/stat changes, world entry, and load.
+
+## Ions: upkeep, heal, starvation
+- **Per-class ion consumption** (per 10s) starts at **level 2** and is **additive** per the approved table (level 1 = 0).
+- **Heal** uses the implemented class/level ion-cost formula; prints “Nothing Happens!” if already at max HP.
+- **Starvation:** at 0 ions, every **10s** lose **1 HP per level** and print yellow **“You’re starving for IONS!”**; ends when ions > 0 or on death.
+
+## Profiles & saves
+- Class menu order: **Thief, Priest, Wizard, Warrior, Mage**; **independent profiles** (year, coords, inventory, ions).
+- First-time world entry per class grants **30000 ions**; “Ready to Combat” resets on death and on any exit.

--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -335,27 +335,21 @@ def make_context(p, w, save, *, dev: bool = False):
             context._suppress_room_render = True
             return False
         if year_input < LOWEST_CENTURY or year_input > HIGHEST_CENTURY:
-            print(yellow("You can only travel from year 2000 to 3000!"))
+            print(yellow(f"You can only travel from year 2000 to {HIGHEST_CENTURY}!"))
             context._needs_render = False
             context._suppress_room_render = True
             return False
         target = max(c for c in ALLOWED_CENTURIES if c <= year_input)
-        if target == p.year:
-            p.travel(w, target)
-            ord_century = ordinal(target // 100)
-            print(yellow(f"You're already in the {ord_century} Century!"))
-        else:
-            steps = abs(target - p.year) // 100
-            cost = ION_TRAVEL_COST * steps
-            if p.ions < cost:
-                print(yellow("***"))
-                print(yellow("You don't have enough ions to create a portal."))
-            else:
-                p.ions -= cost
-                p.travel(w, target)
-                print(
-                    yellow(f"ZAAAAPPPPP!! You've been sent to the year {target} A.D.")
-                )
+        steps = abs(target - p.year) // 100
+        cost = ION_TRAVEL_COST * steps
+        if p.ions < cost:
+            print(yellow("***"))
+            print(yellow("You don't have enough ions to create a portal."))
+            context._suppress_room_render = True
+            return False
+        p.ions -= cost
+        p.travel(w, target)
+        print(yellow(f"ZAAAAPPPPP!! You've been sent to the year {target} A.D."))
         context._suppress_room_render = True
         context._suppress_entry_aggro = True
         context._skip_movement_tick = False

--- a/mutants2/engine/loop.py
+++ b/mutants2/engine/loop.py
@@ -11,12 +11,12 @@ from .player import class_key
 def should_render_room(cmd: str, args: list[str], moved: bool) -> bool:
     """Return ``True`` if the full room view should be printed.
 
-    Only movement/travel that actually changes the room and a bare ``look``
-    request trigger a render. All other commands suppress the room block.
+    Movement that actually changes the room and a bare ``look`` request
+    trigger a render.  ``travel`` always suppresses the room block.
     """
 
     c = cmd.lower()
-    if c in {"north", "south", "east", "west", "last", "travel"}:
+    if c in {"north", "south", "east", "west", "last"}:
         return moved
     if c == "look" and not args:
         return True

--- a/tests/smoke/test_cli_smoke.py
+++ b/tests/smoke/test_cli_smoke.py
@@ -15,5 +15,6 @@ def test_travel_smoke():
     lines = out.strip().splitlines()
     assert lines[0] == "travel 2100"
     assert lines.count("travel 2100") == 1
-    assert "Compass:" in out
+    assert "ZAAAAPPPPP!! You've been sent to the year 2100 A.D." in out
+    assert "Compass:" not in out
     assert "footsteps" not in out.lower()

--- a/tests/smoke/test_look_inventory_only.py
+++ b/tests/smoke/test_look_inventory_only.py
@@ -1,0 +1,37 @@
+import contextlib
+import io
+import datetime
+
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+from mutants2.cli.shell import make_context
+from mutants2.ui.theme import yellow
+
+
+def _ctx(tmp_path):
+    persistence.SAVE_PATH = tmp_path / "save.json"
+    w = world_mod.World({(2000, 0, 0): [{"key": "bug-skin", "enchant": 0}]}, {2000})
+    p = Player(year=2000, clazz="Warrior")
+    save = persistence.Save()
+    save.last_topup_date = datetime.date.today().isoformat()
+    ctx = make_context(p, w, save)
+    return ctx
+
+
+def test_look_inventory_only(tmp_path):
+    ctx = _ctx(tmp_path)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line("look bug")
+    out = buf.getvalue()
+    assert yellow("You can't see bug.") in out
+    assert "Compass:" not in out
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line("get bug")
+        ctx.dispatch_line("look bug")
+    out = buf.getvalue()
+    assert yellow("It looks like a lovely Bug-Skin!") in out
+    assert "Compass:" not in out

--- a/tests/smoke/test_render_gating.py
+++ b/tests/smoke/test_render_gating.py
@@ -1,0 +1,41 @@
+import contextlib
+import io
+
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.player import Player
+from mutants2.cli.shell import make_context
+from mutants2.ui.theme import yellow
+
+
+def _ctx(tmp_path):
+    persistence.SAVE_PATH = tmp_path / "save.json"
+    w = world_mod.World()
+    w.year(2000)
+    w.room_description = lambda *args, **kwargs: "You are here."
+    p = Player(year=2000, clazz="Warrior", ions=100000)
+    save = persistence.Save()
+    ctx = make_context(p, w, save)
+    return ctx, w
+
+
+def test_render_gating(tmp_path):
+    ctx, w = _ctx(tmp_path)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line("east")
+    out = buf.getvalue()
+    assert "You are here." in out and "Compass:" in out
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line("travel 2101")
+    out = buf.getvalue()
+    assert yellow("ZAAAAPPPPP!! You've been sent to the year 2100 A.D.") in out
+    assert "You are here." not in out and "Compass" not in out
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line("look")
+    out = buf.getvalue()
+    assert "You are here." in out and "Compass:" in out

--- a/tests/smoke/test_travel_rounding_copy.py
+++ b/tests/smoke/test_travel_rounding_copy.py
@@ -1,0 +1,39 @@
+import contextlib
+import io
+
+from mutants2.engine import persistence, world as world_mod
+from mutants2.engine.world import HIGHEST_CENTURY
+from mutants2.engine.player import Player
+from mutants2.cli.shell import make_context
+from mutants2.ui.theme import yellow
+
+
+def _ctx(tmp_path):
+    persistence.SAVE_PATH = tmp_path / "save.json"
+    w = world_mod.World()
+    p = Player(clazz="Warrior", ions=100000)
+    save = persistence.Save()
+    ctx = make_context(p, w, save)
+    return ctx
+
+
+def test_travel_rounding_and_bounds(tmp_path):
+    ctx = _ctx(tmp_path)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line("travel 2342")
+    out = buf.getvalue()
+    assert yellow("ZAAAAPPPPP!! You've been sent to the year 2300 A.D.") in out
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line("travel 1999")
+    out = buf.getvalue()
+    assert yellow(f"You can only travel from year 2000 to {HIGHEST_CENTURY}!") in out
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        ctx.dispatch_line("travel 3001")
+    out = buf.getvalue()
+    assert yellow(f"You can only travel from year 2000 to {HIGHEST_CENTURY}!") in out

--- a/tests/smoke/test_travel_yell_and_arrivals.py
+++ b/tests/smoke/test_travel_yell_and_arrivals.py
@@ -53,9 +53,9 @@ def test_same_century_travel_teleports(tmp_path, monkeypatch):
     lines = out.splitlines()
     idxs = [i for i, ln in enumerate(lines) if ln == "travel 2100"]
     second = idxs[1]
-    assert "You're already in the 21st Century!" in lines[second + 1]
+    assert "ZAAAAPPPPP!! You've been sent to the year 2100 A.D." in lines[second + 1]
     look_idx = lines.index("look", second + 1)
-    assert any("Compass" in ln for ln in lines[second + 1 : look_idx])
+    assert all("Compass" not in ln for ln in lines[second + 1 : look_idx])
     assert any("Compass: (0E : 0N)" in ln for ln in lines[look_idx + 1 :])
 
 
@@ -67,6 +67,6 @@ def test_travel_triggers_arrival(tmp_path, monkeypatch):
     w.place_monster(2000, 1, 0, "mutant")
     w.monster_here(2000, 1, 0)["aggro"] = True
     out = run_cli(w, ["travel 2000"], tmp_path, monkeypatch)
-    assert "You're already in the 20th Century!" in out
+    assert "ZAAAAPPPPP!! You've been sent to the year 2000 A.D." in out
     assert "has just arrived from the east" in out
     assert "Compass" not in out

--- a/tests/test_items_prefix_and_abbrev.py
+++ b/tests/test_items_prefix_and_abbrev.py
@@ -74,4 +74,4 @@ def test_abbrev_rules(cli_runner):
 def test_travel_suppresses_render(cli_runner):
     out = cli_runner.run_commands(["tra 2100"])
     assert "ZAAAAPPPPP!!" in out
-    assert out.count("Compass:") == 2
+    assert out.count("Compass:") == 1

--- a/tests/test_no_preaggro_after_travel.py
+++ b/tests/test_no_preaggro_after_travel.py
@@ -66,6 +66,6 @@ def test_no_preaggro_after_travel(cli):
 
 def test_travel_same_century_ticks(cli):
     out = cli.run(["travel 2000"])
-    assert "You're already in the 20th Century!" in out
+    assert "ZAAAAPPPPP!! You've been sent to the year 2000 A.D." in out
     assert "footsteps" not in out.lower()
     assert "Compass" not in out

--- a/tests/test_prefix_rules.py
+++ b/tests/test_prefix_rules.py
@@ -61,7 +61,7 @@ def test_command_prefix_3_to_full(cli):
     for i, cmd in enumerate(cmds):
         out = cli.run([cmd])
         assert "ZAAAAPPPPP!!" in out
-        assert "Compass:" in out
+        assert "Compass:" not in out
         if i < len(cmds) - 1:
             cli.run(["travel 2000"])
     out = cli.run(["tr 2100"])

--- a/tests/test_travel_cost.py
+++ b/tests/test_travel_cost.py
@@ -52,6 +52,6 @@ def test_travel_insufficient_ions_no_move():
 
 def test_same_century_travel_free_and_resets_position():
     out, p = run(["east", "travel 2700"], ions=5_000, start_year=2700, start_pos=(1, 0))
-    assert yellow("You're already in the 27th Century!") in out
+    assert yellow("ZAAAAPPPPP!! You've been sent to the year 2700 A.D.") in out
     assert p.ions == 5_000
     assert p.positions[2700] == (0, 0)


### PR DESCRIPTION
## Summary
- document updated Single Source of Truth for agents and travel rules
- suppress room render on `travel` while movement and bare `look` re-render
- add smoke tests for travel rounding, render gating, and inventory-only look

## Testing
- `black .`
- `ruff check .`
- `pyright mutants2`
- `vulture mutants2`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beedcd8df0832bbcc86abed3fd826b