### PR TITLE
refactor: centralize color semantics

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -9,6 +9,16 @@ This document defines the contracts our agents (and humans) must follow.
 - **Determinism:** The world is deterministically seeded **only in the CLI entrypoint**; tests must use a **temporary SAVE_PATH** and opt-in seeding.
 - **Worn ≠ inventory:** Worn items are not in inventory scope; use helpers like `resolve_item(prefix, scope="inventory"|"worn")`.
 
+## Color palette & usage
+- **green** — Compass line (e.g., `Compass: (0E : 0N)`).
+- **cyan** — Cardinal direction token on exit lines (`north`, `south`, `east`, `west`).
+- **blue** — Exit description segment after the en-dash (e.g., `area continues.`).  If an exit copy variant is used, the whole post-dash portion is blue.
+- **yellow** — Generic feedback & help; prompts; “lovely” look-for-item line; inventory-scope failures (`You can't see <raw_subject>.`, `You're not carrying <raw_subject>.`); shadows header; ground header (`On the ground lies:`).
+- **white** — Class selection menu; inventory list body; monster names shown in room renders (from look or `look <dir>`); monster taunts/native attacks (e.g., `Critter-750 bites you!`).
+- **red** — Room header/description; ion conversion feedback; kill & loot/rewards; monster arrival/leave; “crumbling to dust” after loot; weapon/armor crack; ranged “blinding flash”; monster spell preamble; spell damage descriptions.
+
+Numbers are always plain (no commas).
+
 ## Core world & movement
 - Each century is a **30×30** grid; edges block; center is **(0E : 0N)**.
 - **Centuries enabled:** **2000–3000** inclusive, in 100-year steps.
@@ -25,19 +35,19 @@ This document defines the contracts our agents (and humans) must follow.
 ## Look semantics
 - `look` (no args): on-tile peek that can trigger aggro checks.
 - `look <item>` searches **inventory only**.  
-  – If found and spawnable: print yellow **“It looks like a lovely <Title-Case Item-Name>!”**.  
-  – If not in inventory (on ground or worn): print yellow using the raw token: **“You can't see `<raw_subject>`.”**  
+  – If found and spawnable: print **“It looks like a lovely <Title-Case Item-Name>!”**.
+  – If not in inventory (on ground or worn): print using the raw token: **“You can't see `<raw_subject>`.”**
 - `look <dir>` peeks without shadows.
 
 ## Aggro, footsteps, arrivals
 - Monsters spawn **passive**; on room entry or `look` (no args) on a shared tile: **50/50** to aggro; on success, yell once: **“<Name> yells at you!”**.
 - Only **aggro** monsters move one step after the player turn; if none aggro in-year, **skip** the movement tick.  
 - **Footsteps:** loud at **2**, faint at **3–6**, none at **<1**; supports intermediate directions (e.g., “south-west”).  
-- In an arrival tick, render **arrivals (red) last** and **suppress** the generic presence line.
+- In an arrival tick, render arrivals last and **suppress** the generic presence line.
 
 ## Monsters, targeting, and rewards
 - Multiple monsters can share a tile; names include a **unique 4-digit suffix** (e.g., `Mutant-1846`).
-- **`combat <monster>`** selects a target (consumes a turn) and prints yellow **“You’re ready to combat <Name>!”**; legacy `attack` is removed.
+- **`combat <monster>`** selects a target (consumes a turn) and prints **“You’re ready to combat <Name>!”**; legacy `attack` is removed.
 - Wielding hits only if **ready to combat** someone.  
 - On kill: award **20000 riblets** and **20000 ions**.
 
@@ -52,7 +62,7 @@ This document defines the contracts our agents (and humans) must follow.
 ## Ions: upkeep, heal, starvation
 - **Per-class ion consumption** (per 10s) starts at **level 2** and is **additive** per the approved table (level 1 = 0).
 - **Heal** uses the implemented class/level ion-cost formula; prints “Nothing Happens!” if already at max HP.
-- **Starvation:** at 0 ions, every **10s** lose **1 HP per level** and print yellow **“You’re starving for IONS!”**; ends when ions > 0 or on death.
+- **Starvation:** at 0 ions, every **10s** lose **1 HP per level** and print **“You’re starving for IONS!”**; ends when ions > 0 or on death.
 
 ## Profiles & saves
 - Class menu order: **Thief, Priest, Wizard, Warrior, Mage**; **independent profiles** (year, coords, inventory, ions).

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -1,4 +1,11 @@
-from .theme import yellow, red, SEP
+from .theme import SEP
+from .strings import (
+    help_text,
+    generic_fb,
+    kill_reward,
+    exits_dir,
+    exits_desc,
+)
 import re
 
 NBSP = "\u00a0"  # non-breaking space
@@ -41,10 +48,15 @@ def wrap_ansi(text: str, width: int = 80) -> str:
     return "\n".join(" ".join(line) for line in lines if line)
 
 
+def render_single_exit(direction: str, desc: str) -> str:
+    pad = max(0, 5 - len(direction))
+    return f"{exits_dir(direction)}{' ' * pad} – {exits_desc(desc)}"
+
+
 def render_help_hint() -> None:
-    """Print the standard help hint in yellow."""
+    """Print the standard help hint."""
     print(SEP)
-    print(yellow("Type ? if you need assistance."))
+    print(help_text("Type ? if you need assistance."))
 
 
 def print_yell(mon) -> str:
@@ -66,38 +78,38 @@ def render_status(p) -> list[str]:
         idef = get_item_def_by_key(inst["key"])
         armor_name = display_item_name_plain(inst, idef)
     lines = [
-        yellow(f"Name: Vindeiatrix / Mutant {disp}"),
-        yellow("Exhaustion   : 0"),
-        yellow(
+        generic_fb(f"Name: Vindeiatrix / Mutant {disp}"),
+        generic_fb("Exhaustion   : 0"),
+        generic_fb(
             f"Str: {fmt(p.strength):<2}   Int: {fmt(p.intelligence):<2}   Wis: {fmt(p.wisdom):<2}"
         ),
-        yellow(
+        generic_fb(
             f"Dex: {fmt(p.dexterity):<2}   Con: {fmt(p.constitution):<2}   Cha: {fmt(p.charisma):<2}"
         ),
-        yellow(f"Hit Points   : {fmt(p.hp)} / {fmt(p.max_hp)}"),
-        yellow(f"Exp. Points  : {fmt(p.exp)}           Level: {fmt(p.level)}"),
-        yellow(f"Riblets      : {fmt(getattr(p, 'riblets', 0))}"),
-        yellow(f"Ions         : {fmt(p.ions)}"),
-        yellow(f"Wearing Armor: {armor_name}  Armour Class: {fmt(p.ac_total)}"),
-        yellow(
+        generic_fb(f"Hit Points   : {fmt(p.hp)} / {fmt(p.max_hp)}"),
+        generic_fb(f"Exp. Points  : {fmt(p.exp)}           Level: {fmt(p.level)}"),
+        generic_fb(f"Riblets      : {fmt(getattr(p, 'riblets', 0))}"),
+        generic_fb(f"Ions         : {fmt(p.ions)}"),
+        generic_fb(f"Wearing Armor: {armor_name}  Armour Class: {fmt(p.ac_total)}"),
+        generic_fb(
             f"Ready to Combat: {p.ready_to_combat_name}"
             if p.ready_to_combat_name
             else "Ready to Combat: NO ONE"
         ),
-        yellow("Readied Spell : No spell memorized."),
-        yellow(f"Year A.D.     : {fmt(p.year)}"),
+        generic_fb("Readied Spell : No spell memorized."),
+        generic_fb(f"Year A.D.     : {fmt(p.year)}"),
         "",
     ]
     return lines
 
 
 def render_kill_block(name: str, xp: int, riblets: int, ions: int) -> None:
-    """Render the red kill message block for monster deaths."""
-    print(red(f"You have slain {name}!"))
-    print(red(f"Your experience points are increased by {fmt(xp)}!"))
+    """Render the kill message block for monster deaths."""
+    print(kill_reward(f"You have slain {name}!"))
+    print(kill_reward(f"Your experience points are increased by {fmt(xp)}!"))
     print(
-        red(
+        kill_reward(
             f"You collect {fmt(riblets)} Riblets and {fmt(ions)} ions from the slain body."
         )
     )
-    print("***")
+    print(SEP)

--- a/mutants2/ui/strings.py
+++ b/mutants2/ui/strings.py
@@ -1,5 +1,22 @@
-from .theme import yellow
+from .theme import green, cyan, blue, yellow, red, white
 
+# semantic color wrappers
+room_header = red
+compass_line = green
+exits_dir = cyan
+exits_desc = blue
+ground_header = yellow
+ground_list = cyan
+presence_line = white
+shadows_line = yellow
+help_text = yellow
+generic_fb = yellow
+convert_fb = red
+kill_reward = red
+arrival_line = red
+spell_line = red
+
+# string constants
 GET_WHAT = "What do you want to get?"
 DROP_WHAT = "What do you want to drop?"
 NOT_ENOUGH_IONS_PORTAL = "You don't have enough ions to create a portal."
@@ -7,10 +24,6 @@ CANT_SEE = "You can't see {0}."
 
 
 def not_carrying(raw: str) -> str:
-    """Return the yellow not-carrying message for ``raw``.
+    """Return the not-carrying message for ``raw``."""
 
-    ``raw`` is the exact subject as typed by the user with surrounding
-    whitespace trimmed.
-    """
-
-    return yellow(f"You're not carrying {raw}.")
+    return generic_fb(f"You're not carrying {raw}.")

--- a/mutants2/ui/theme.py
+++ b/mutants2/ui/theme.py
@@ -1,23 +1,27 @@
 NO_COLOR = False  # honor an env/config flag if you already have one
 
 
-def red(s):
-    return s if NO_COLOR else f"\x1b[31m{s}\x1b[0m"
-
-
-def green(s):
+def green(s: str) -> str:
     return s if NO_COLOR else f"\x1b[32m{s}\x1b[0m"
 
 
-def cyan(s):
+def cyan(s: str) -> str:
     return s if NO_COLOR else f"\x1b[36m{s}\x1b[0m"
 
 
-def yellow(s):
+def blue(s: str) -> str:
+    return s if NO_COLOR else f"\x1b[34m{s}\x1b[0m"
+
+
+def yellow(s: str) -> str:
     return s if NO_COLOR else f"\x1b[33m{s}\x1b[0m"
 
 
-def white(s):
+def red(s: str) -> str:
+    return s if NO_COLOR else f"\x1b[31m{s}\x1b[0m"
+
+
+def white(s: str) -> str:
     return s if NO_COLOR else f"\x1b[37m{s}\x1b[0m"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ dependencies = []
 
 [tool.pytest.ini_options]
 addopts = "-q"
+markers = [
+  "ui",
+  "smoke",
+  "items",
+  "combat",
+]
 
 [project.optional-dependencies]
 dev = [

--- a/tests/smoke/test_bug_skin_add_convert_look.py
+++ b/tests/smoke/test_bug_skin_add_convert_look.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from mutants2.engine import persistence, world as world_mod
 from mutants2.engine.player import Player
 from mutants2.cli.shell import make_context
-from mutants2.ui.theme import yellow
+from mutants2.ui.theme import yellow, red
 
 
 def run_commands(cmds, path, setup=None):
@@ -59,8 +59,8 @@ def test_look_and_convert_inventory(tmp_path):
         tmp_path / "inv",
     )
     assert "possesses a magical aura" in out
-    assert yellow("The Bug-Skin vanishes with a flash!") in out
-    assert yellow("You convert the Bug-Skin into 22100 ions.") in out
+    assert red("The Bug-Skin vanishes with a flash!") in out
+    assert red("You convert the Bug-Skin into 22100 ions.") in out
     assert "Bug-Skin" not in out.split("inventory")[-1]
     assert p.ions == 22100
 

--- a/tests/smoke/test_look_inventory_only_and_exits_spacing.py
+++ b/tests/smoke/test_look_inventory_only_and_exits_spacing.py
@@ -5,7 +5,7 @@ import io
 from mutants2.engine import persistence, world as world_mod
 from mutants2.engine.player import Player
 from mutants2.cli.shell import make_context
-from mutants2.ui.theme import yellow, cyan
+from mutants2.ui.theme import yellow, cyan, blue
 
 
 def _ctx(tmp_path):
@@ -45,7 +45,11 @@ def test_exit_spacing(tmp_path):
     with contextlib.redirect_stdout(buf):
         ctx.dispatch_line("look")
     out = buf.getvalue()
-    assert cyan("north – area continues.") in out
-    assert cyan("south – area continues.") in out
-    assert cyan("east  – area continues.") in out
-    assert cyan("west  – area continues.") in out
+    north_line = f"{cyan('north')} – {blue('area continues.')}"
+    south_line = f"{cyan('south')} – {blue('area continues.')}"
+    east_line = f"{cyan('east')}  – {blue('area continues.')}"
+    west_line = f"{cyan('west')}  – {blue('area continues.')}"
+    assert north_line in out
+    assert south_line in out
+    assert east_line in out
+    assert west_line in out

--- a/tests/smoke/test_travel_convert_and_items.py
+++ b/tests/smoke/test_travel_convert_and_items.py
@@ -5,7 +5,7 @@ import datetime
 from mutants2.engine import persistence, items
 from mutants2.engine.player import Player
 from mutants2.engine.world import World
-from mutants2.ui.theme import yellow
+from mutants2.ui.theme import yellow, red
 
 
 def test_monster_bait_conversion(cli_runner, tmp_path):
@@ -21,8 +21,8 @@ def test_monster_bait_conversion(cli_runner, tmp_path):
     item = items.REGISTRY["monster_bait"]
     assert item.weight_lbs == 10
     assert item.ion_value == 10000
-    assert yellow("The Monster-Bait vanishes with a flash!") in out
-    assert yellow("You convert the Monster-Bait into 10000 ions.") in out
+    assert red("The Monster-Bait vanishes with a flash!") in out
+    assert red("You convert the Monster-Bait into 10000 ions.") in out
     assert "(empty)" not in out
     assert "Ions         : 40000" in out
 

--- a/tests/test_convert_command.py
+++ b/tests/test_convert_command.py
@@ -6,7 +6,7 @@ import pytest
 from mutants2.engine import persistence
 from mutants2.engine.player import Player
 from mutants2.engine.world import World
-from mutants2.ui.theme import yellow
+from mutants2.ui.theme import red
 
 
 @pytest.fixture
@@ -25,7 +25,7 @@ def inventory_with_cap(tmp_path):
 def test_convert_bottle_cap(cli_runner, inventory_with_cap):
     out = cli_runner.run_commands(["convert b", "inventory", "status"])
     assert out.count("***") == 2
-    assert yellow("The Bottle-Cap vanishes with a flash!") in out
-    assert yellow("You convert the Bottle-Cap into 22000 ions.") in out
+    assert red("The Bottle-Cap vanishes with a flash!") in out
+    assert red("You convert the Bottle-Cap into 22000 ions.") in out
     assert "(empty)" not in out
     assert "Ions         : 52000" in out

--- a/tests/ui/test_exits_color_split.py
+++ b/tests/ui/test_exits_color_split.py
@@ -1,0 +1,10 @@
+import pytest
+from mutants2.ui.theme import cyan, blue
+from mutants2.ui.render import render_single_exit
+
+
+@pytest.mark.ui
+def test_exits_color_split():
+    line = render_single_exit("north", "area continues.")
+    assert line.startswith(cyan("north"))
+    assert blue("area continues.") in line

--- a/tests/ui/test_kill_reward_color.py
+++ b/tests/ui/test_kill_reward_color.py
@@ -1,0 +1,12 @@
+import pytest
+from mutants2.ui.theme import red
+from mutants2.ui.render import render_kill_block
+
+
+@pytest.mark.ui
+def test_kill_reward_color(capsys):
+    render_kill_block("Mutant-1", 1, 2, 3)
+    out = capsys.readouterr().out
+    assert red("You have slain Mutant-1!") in out
+    assert red("Your experience points are increased by 1!") in out
+    assert red("You collect 2 Riblets and 3 ions from the slain body.") in out


### PR DESCRIPTION
## Summary
- document color palette and semantics
- route rendering through color helpers and split exit colors
- exercise new palette in tests

## Testing
- `black .`
- `ruff check .`
- `pyright` *(fails: Object of type "None" is not subscriptable and other type errors)*
- `vulture .`
- `pytest -q -m "ui or smoke or items or combat"`

------
https://chatgpt.com/codex/tasks/task_e_68befcff81c0832ba5e637639181ba4b