### PR TITLE
Use item color for exits, stats and loot messages

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -11,11 +11,11 @@ This document defines the contracts our agents (and humans) must follow.
 
 ## Color palette & usage
 - **green** — Compass line (e.g., `Compass: (0E : 0N)`).
-- **cyan** — Cardinal direction token on exit lines (`north`, `south`, `east`, `west`).
-- **blue** — Exit description segment after the en-dash (e.g., `area continues.`).  If an exit copy variant is used, the whole post-dash portion is blue.
-- **yellow** — Generic feedback & help; prompts; “lovely” look-for-item line; inventory-scope failures (`You can't see <raw_subject>.`, `You're not carrying <raw_subject>.`); shadows header; ground header (`On the ground lies:`).
+- **header color** — Section titles like `On the ground lies:` and cardinal direction words (`north`, `south`, `east`, `west`).
+- **item color** — Ground item names and exit description segments after the en-dash (e.g., `area continues.`).
+- **yellow** — Generic feedback & help; prompts; “lovely” look-for-item line; inventory-scope failures (`You can't see <raw_subject>.`, `You're not carrying <raw_subject>.`); shadows header.
 - **white** — Class selection menu; inventory list body; monster names shown in room renders (from look or `look <dir>`); monster taunts/native attacks (e.g., `Critter-750 bites you!`).
-- **red** — Room header/description; ion conversion feedback; kill & loot/rewards; monster arrival/leave; “crumbling to dust” after loot; weapon/armor crack; ranged “blinding flash”; monster spell preamble; spell damage descriptions.
+- **red** — Room header/description; ion conversion feedback; kill & loot/rewards; monster arrival/leave; “crumbling to dust” after loot; weapon/armor crack; ranged “blinding flash”; monster spell preamble; spell damage descriptions; monster picks up an item; monster converts an item to ions; monster drops an item.
 
 Numbers are always plain (no commas).
 

--- a/mutants2/engine/combat.py
+++ b/mutants2/engine/combat.py
@@ -7,8 +7,9 @@ import math
 from .leveling import check_level_up
 from . import items as items_mod
 from ..data.config import AC_DIVISOR
-from ..ui.render import render_kill_block, fmt
-from ..ui.theme import yellow
+from ..ui.render import render_kill_block
+from ..ui.theme import SEP
+from ..ui.strings import kill_reward
 
 MONSTER_XP = 20_000
 
@@ -47,7 +48,8 @@ def player_attack(player, world, weapon_key: str):
         riblets = 20_000
         player.ions += ions
         player.riblets += riblets
-        xp = award_kill(player)
-        render_kill_block(name, xp, riblets, ions)
-        print(yellow(f"You gain {fmt(riblets)} riblets and {fmt(ions)} ions."))
+        award_kill(player)
+        render_kill_block(riblets, ions)
+        print(SEP)
+        print(kill_reward(f"{name} is crumbling to dust!"))
     return dmg, killed, name

--- a/mutants2/ui/render.py
+++ b/mutants2/ui/render.py
@@ -1,10 +1,7 @@
-from .theme import SEP
+from .theme import SEP, COLOR_HEADER, COLOR_ITEM
 from .strings import (
     help_text,
-    generic_fb,
     kill_reward,
-    exits_dir,
-    exits_desc,
 )
 import re
 
@@ -50,7 +47,7 @@ def wrap_ansi(text: str, width: int = 80) -> str:
 
 def render_single_exit(direction: str, desc: str) -> str:
     pad = max(0, 5 - len(direction))
-    return f"{exits_dir(direction)}{' ' * pad} – {exits_desc(desc)}"
+    return f"{COLOR_HEADER(direction)}{' ' * pad} – {COLOR_ITEM(desc)}"
 
 
 def render_help_hint() -> None:
@@ -78,38 +75,42 @@ def render_status(p) -> list[str]:
         idef = get_item_def_by_key(inst["key"])
         armor_name = display_item_name_plain(inst, idef)
     lines = [
-        generic_fb(f"Name: Vindeiatrix / Mutant {disp}"),
-        generic_fb("Exhaustion   : 0"),
-        generic_fb(
-            f"Str: {fmt(p.strength):<2}   Int: {fmt(p.intelligence):<2}   Wis: {fmt(p.wisdom):<2}"
+        f"{COLOR_ITEM('Name:')} Vindeiatrix / Mutant {disp}",
+        f"{COLOR_ITEM('Exhaustion   :')} 0",
+        (
+            f"{COLOR_ITEM('Str:')} {fmt(p.strength):<2}   "
+            f"{COLOR_ITEM('Int:')} {fmt(p.intelligence):<2}   "
+            f"{COLOR_ITEM('Wis:')} {fmt(p.wisdom):<2}"
         ),
-        generic_fb(
-            f"Dex: {fmt(p.dexterity):<2}   Con: {fmt(p.constitution):<2}   Cha: {fmt(p.charisma):<2}"
+        (
+            f"{COLOR_ITEM('Dex:')} {fmt(p.dexterity):<2}   "
+            f"{COLOR_ITEM('Con:')} {fmt(p.constitution):<2}   "
+            f"{COLOR_ITEM('Cha:')} {fmt(p.charisma):<2}"
         ),
-        generic_fb(f"Hit Points   : {fmt(p.hp)} / {fmt(p.max_hp)}"),
-        generic_fb(f"Exp. Points  : {fmt(p.exp)}           Level: {fmt(p.level)}"),
-        generic_fb(f"Riblets      : {fmt(getattr(p, 'riblets', 0))}"),
-        generic_fb(f"Ions         : {fmt(p.ions)}"),
-        generic_fb(f"Wearing Armor: {armor_name}  Armour Class: {fmt(p.ac_total)}"),
-        generic_fb(
-            f"Ready to Combat: {p.ready_to_combat_name}"
+        f"{COLOR_ITEM('Hit Points   :')} {fmt(p.hp)} / {fmt(p.max_hp)}",
+        f"{COLOR_ITEM('Exp. Points  :')} {fmt(p.exp)}           {COLOR_ITEM('Level:')} {fmt(p.level)}",
+        f"{COLOR_ITEM('Riblets      :')} {fmt(getattr(p, 'riblets', 0))}",
+        f"{COLOR_ITEM('Ions         :')} {fmt(p.ions)}",
+        (
+            f"{COLOR_ITEM('Wearing Armor:')} {armor_name}  "
+            f"{COLOR_ITEM('Armour Class:')} {fmt(p.ac_total)}"
+        ),
+        (
+            f"{COLOR_ITEM('Ready to Combat:')} {p.ready_to_combat_name}"
             if p.ready_to_combat_name
-            else "Ready to Combat: NO ONE"
+            else f"{COLOR_ITEM('Ready to Combat:')} NO ONE"
         ),
-        generic_fb("Readied Spell : No spell memorized."),
-        generic_fb(f"Year A.D.     : {fmt(p.year)}"),
+        f"{COLOR_ITEM('Readied Spell :')} No spell memorized.",
+        f"{COLOR_ITEM('Year A.D.     :')} {fmt(p.year)}",
         "",
     ]
     return lines
 
 
-def render_kill_block(name: str, xp: int, riblets: int, ions: int) -> None:
-    """Render the kill message block for monster deaths."""
-    print(kill_reward(f"You have slain {name}!"))
-    print(kill_reward(f"Your experience points are increased by {fmt(xp)}!"))
+def render_kill_block(riblets: int, ions: int) -> None:
+    """Render the loot collection line for monster deaths."""
     print(
         kill_reward(
             f"You collect {fmt(riblets)} Riblets and {fmt(ions)} ions from the slain body."
         )
     )
-    print(SEP)

--- a/mutants2/ui/strings.py
+++ b/mutants2/ui/strings.py
@@ -1,16 +1,16 @@
-from .theme import green, cyan, blue, yellow, red, white
+from .theme import green, red, white, COLOR_HEADER, COLOR_ITEM
 
 # semantic color wrappers
 room_header = red
 compass_line = green
-exits_dir = cyan
-exits_desc = blue
-ground_header = yellow
-ground_list = cyan
+exits_dir = COLOR_HEADER
+exits_desc = COLOR_ITEM
+ground_header = COLOR_HEADER
+ground_list = COLOR_ITEM
 presence_line = white
-shadows_line = yellow
-help_text = yellow
-generic_fb = yellow
+shadows_line = COLOR_HEADER
+help_text = COLOR_HEADER
+generic_fb = COLOR_HEADER
 convert_fb = red
 kill_reward = red
 arrival_line = red

--- a/mutants2/ui/theme.py
+++ b/mutants2/ui/theme.py
@@ -9,10 +9,6 @@ def cyan(s: str) -> str:
     return s if NO_COLOR else f"\x1b[36m{s}\x1b[0m"
 
 
-def blue(s: str) -> str:
-    return s if NO_COLOR else f"\x1b[34m{s}\x1b[0m"
-
-
 def yellow(s: str) -> str:
     return s if NO_COLOR else f"\x1b[33m{s}\x1b[0m"
 
@@ -24,5 +20,13 @@ def red(s: str) -> str:
 def white(s: str) -> str:
     return s if NO_COLOR else f"\x1b[37m{s}\x1b[0m"
 
+
+COLOR_HEADER = yellow
+COLOR_ITEM = cyan
+
+# ``blue`` previously represented a lighter variant used for exit descriptions.
+# It is now an alias of ``COLOR_ITEM`` to remove that tone from the palette
+# while keeping backwards compatibility.
+blue = cyan
 
 SEP = white("***")

--- a/tests/smoke/test_combat_ready_target.py
+++ b/tests/smoke/test_combat_ready_target.py
@@ -76,4 +76,5 @@ def test_target_cleared_on_monster_death():
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
         ctx.dispatch_line("status")
-    assert "Ready to Combat: NO ONE" in buf.getvalue()
+    out = re.sub(r"\x1b\[[0-9;]*m", "", buf.getvalue())
+    assert "Ready to Combat: NO ONE" in out

--- a/tests/smoke/test_equip_render_rewards.py
+++ b/tests/smoke/test_equip_render_rewards.py
@@ -70,7 +70,9 @@ def test_kill_rewards():
     out, _, p = run_commands(
         ["get light", "combat mutant", "wield light", "status"], setup=setup
     )
-    assert "You gain 20000 riblets and 20000 ions." in out
+    assert "You collect 20000 Riblets and 20000 ions from the slain body." in out
+    assert re.search(r"\*\*\*\nMutant-\d{4} is crumbling to dust!", out)
+    assert "You gain" not in out
     assert p.riblets == 20000 and p.ions == 20000
 
 

--- a/tests/smoke/test_look_inventory_only_and_exits_spacing.py
+++ b/tests/smoke/test_look_inventory_only_and_exits_spacing.py
@@ -5,7 +5,7 @@ import io
 from mutants2.engine import persistence, world as world_mod
 from mutants2.engine.player import Player
 from mutants2.cli.shell import make_context
-from mutants2.ui.theme import yellow, cyan, blue
+from mutants2.ui.theme import COLOR_HEADER, COLOR_ITEM
 
 
 def _ctx(tmp_path):
@@ -24,7 +24,7 @@ def test_look_inventory_only(tmp_path):
     with contextlib.redirect_stdout(buf):
         ctx.dispatch_line("look nuclear")
     out = buf.getvalue()
-    assert yellow("You can't see nuclear.") in out
+    assert COLOR_HEADER("You can't see nuclear.") in out
     assert "You are here." not in out
     assert "Compass:" not in out
     assert w.turn == 1
@@ -33,7 +33,7 @@ def test_look_inventory_only(tmp_path):
         ctx.dispatch_line("get nuclear-rock")
         ctx.dispatch_line("look nuclear")
     out = buf.getvalue()
-    assert yellow("It looks like a lovely Nuclear-Rock!") in out
+    assert COLOR_HEADER("It looks like a lovely Nuclear-Rock!") in out
     assert "You are here." not in out
     assert "Compass:" not in out
     assert w.turn == 3
@@ -45,11 +45,12 @@ def test_exit_spacing(tmp_path):
     with contextlib.redirect_stdout(buf):
         ctx.dispatch_line("look")
     out = buf.getvalue()
-    north_line = f"{cyan('north')} – {blue('area continues.')}"
-    south_line = f"{cyan('south')} – {blue('area continues.')}"
-    east_line = f"{cyan('east')}  – {blue('area continues.')}"
-    west_line = f"{cyan('west')}  – {blue('area continues.')}"
+    north_line = f"{COLOR_HEADER('north')} – {COLOR_ITEM('area continues.')}"
+    south_line = f"{COLOR_HEADER('south')} – {COLOR_ITEM('area continues.')}"
+    east_line = f"{COLOR_HEADER('east')}  – {COLOR_ITEM('area continues.')}"
+    west_line = f"{COLOR_HEADER('west')}  – {COLOR_ITEM('area continues.')}"
     assert north_line in out
     assert south_line in out
     assert east_line in out
     assert west_line in out
+    assert "\x1b[34m" not in out

--- a/tests/smoke/test_render_enumeration_and_wrap.py
+++ b/tests/smoke/test_render_enumeration_and_wrap.py
@@ -5,7 +5,7 @@ import io
 from mutants2.engine import persistence, world as world_mod
 from mutants2.engine.player import Player
 from mutants2.cli.shell import make_context
-from mutants2.ui.theme import yellow, white, cyan
+from mutants2.ui.theme import COLOR_HEADER, COLOR_ITEM, white
 
 
 def _ctx(tmp_path):
@@ -26,8 +26,8 @@ def test_enumeration_and_wrap(tmp_path):
         ctx.dispatch_line("debug item add cheese 2")
         ctx.dispatch_line("look")
     out = buf.getvalue()
-    assert yellow("On the ground lies:") in out
-    assert cyan("A Cheese, A Cheese\u00a0(1).") in out
+    assert COLOR_HEADER("On the ground lies:") in out
+    assert COLOR_ITEM("A Cheese, A Cheese\u00a0(1).") in out
 
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):

--- a/tests/smoke/test_stats_page.py
+++ b/tests/smoke/test_stats_page.py
@@ -5,7 +5,7 @@ import io
 from mutants2.engine import persistence, world as world_mod
 from mutants2.engine.player import Player
 from mutants2.cli.shell import make_context
-from mutants2.ui.theme import yellow, white
+from mutants2.ui.theme import COLOR_ITEM, COLOR_HEADER, white
 
 
 def test_stats_page(tmp_path):
@@ -20,11 +20,12 @@ def test_stats_page(tmp_path):
     with contextlib.redirect_stdout(buf):
         ctx.dispatch_line("status")
     out = buf.getvalue()
-    assert yellow("Name: Vindeiatrix / Mutant Warrior") in out
-    assert yellow("Hit Points   : 40 / 40") in out
-    assert yellow("Ions         : 0") in out
-    assert yellow("Year A.D.     : 2000") in out
+    assert f"{COLOR_ITEM('Name:')} Vindeiatrix / Mutant Warrior" in out
+    assert f"{COLOR_ITEM('Hit Points   :')} 40 / 40" in out
+    assert f"{COLOR_ITEM('Ions         :')} 0" in out
+    assert f"{COLOR_ITEM('Year A.D.     :')} 2000" in out
     assert (
-        yellow("You are carrying the following items:  (Total Weight: 45 LB's)") in out
+        COLOR_HEADER("You are carrying the following items:  (Total Weight: 45 LB's)")
+        in out
     )
     assert white("Ion-Decay, Ion-Decay\u00a0(1), Gold-Chunk.") in out

--- a/tests/smoke/test_travel_convert_and_items.py
+++ b/tests/smoke/test_travel_convert_and_items.py
@@ -5,7 +5,7 @@ import datetime
 from mutants2.engine import persistence, items
 from mutants2.engine.player import Player
 from mutants2.engine.world import World
-from mutants2.ui.theme import yellow, red
+from mutants2.ui.theme import yellow, red, COLOR_ITEM
 
 
 def test_monster_bait_conversion(cli_runner, tmp_path):
@@ -24,7 +24,7 @@ def test_monster_bait_conversion(cli_runner, tmp_path):
     assert red("The Monster-Bait vanishes with a flash!") in out
     assert red("You convert the Monster-Bait into 10000 ions.") in out
     assert "(empty)" not in out
-    assert "Ions         : 40000" in out
+    assert f"{COLOR_ITEM('Ions         :')} 40000" in out
 
 
 def test_convert_gibberish(cli_runner):
@@ -35,7 +35,7 @@ def test_convert_gibberish(cli_runner):
 def test_travel_rounding_and_stats(cli_runner):
     out = cli_runner.run_commands(["tra 2345", "status"])
     assert yellow("ZAAAAPPPPP!! You've been sent to the year 2300 A.D.") in out
-    assert "Year A.D.     : 2300" in out
+    assert f"{COLOR_ITEM('Year A.D.     :')} 2300" in out
 
 
 def test_travel_out_of_range(cli_runner):

--- a/tests/test_convert_command.py
+++ b/tests/test_convert_command.py
@@ -6,7 +6,7 @@ import pytest
 from mutants2.engine import persistence
 from mutants2.engine.player import Player
 from mutants2.engine.world import World
-from mutants2.ui.theme import red
+from mutants2.ui.theme import red, COLOR_ITEM
 
 
 @pytest.fixture
@@ -28,4 +28,4 @@ def test_convert_bottle_cap(cli_runner, inventory_with_cap):
     assert red("The Bottle-Cap vanishes with a flash!") in out
     assert red("You convert the Bottle-Cap into 22000 ions.") in out
     assert "(empty)" not in out
-    assert "Ions         : 52000" in out
+    assert f"{COLOR_ITEM('Ions         :')} 52000" in out

--- a/tests/test_player_ions_inventory_weight.py
+++ b/tests/test_player_ions_inventory_weight.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from mutants2.engine import persistence
 from mutants2.engine.player import Player
 from mutants2.engine.world import World
-from mutants2.ui.theme import yellow, white
+from mutants2.ui.theme import COLOR_HEADER, COLOR_ITEM, white
 
 
 def test_inventory_weight_and_stats(cli_runner, tmp_path):
@@ -21,9 +21,10 @@ def test_inventory_weight_and_stats(cli_runner, tmp_path):
 
     # Inventory header and weight
     assert (
-        yellow("You are carrying the following items: (Total Weight: 45 LB's)") in out
+        COLOR_HEADER("You are carrying the following items: (Total Weight: 45 LB's)")
+        in out
     )
     assert white("Ion-Decay, Ion-Decay\u00a0(1), Gold-Chunk.") in out
 
     # Stats page ions
-    assert "Ions         : 30000" in out
+    assert f"{COLOR_ITEM('Ions         :')} 30000" in out

--- a/tests/ui/test_exits_color_split.py
+++ b/tests/ui/test_exits_color_split.py
@@ -1,10 +1,10 @@
 import pytest
-from mutants2.ui.theme import cyan, blue
+from mutants2.ui.theme import COLOR_HEADER, COLOR_ITEM
 from mutants2.ui.render import render_single_exit
 
 
 @pytest.mark.ui
 def test_exits_color_split():
     line = render_single_exit("north", "area continues.")
-    assert line.startswith(cyan("north"))
-    assert blue("area continues.") in line
+    assert line.startswith(COLOR_HEADER("north"))
+    assert COLOR_ITEM("area continues.") in line

--- a/tests/ui/test_kill_reward_color.py
+++ b/tests/ui/test_kill_reward_color.py
@@ -5,8 +5,6 @@ from mutants2.ui.render import render_kill_block
 
 @pytest.mark.ui
 def test_kill_reward_color(capsys):
-    render_kill_block("Mutant-1", 1, 2, 3)
+    render_kill_block(2, 3)
     out = capsys.readouterr().out
-    assert red("You have slain Mutant-1!") in out
-    assert red("Your experience points are increased by 1!") in out
     assert red("You collect 2 Riblets and 3 ions from the slain body.") in out

--- a/tests/ui/test_loot_flow.py
+++ b/tests/ui/test_loot_flow.py
@@ -1,0 +1,25 @@
+import contextlib
+import io
+import re
+
+from mutants2.engine.world import World
+from mutants2.engine.player import Player
+from mutants2.engine.combat import player_attack
+from mutants2.ui.theme import red
+
+
+def test_loot_flow_single_line_and_crumble():
+    w = World()
+    w.year(2000)
+    w.place_monster(2000, 0, 0, "mutant")
+    p = Player(year=2000, clazz="Warrior")
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        player_attack(p, w, "nuclear_rock")
+    out = buf.getvalue()
+    assert red("You collect 20000 Riblets and 20000 ions from the slain body.") in out
+    assert re.search(r"You gain \d+ riblets", out) is None
+    assert re.search(
+        r"\x1b\[37m\*\*\*\x1b\[0m\n\x1b\[31mMutant-\d{4} is crumbling to dust!\x1b\[0m",
+        out,
+    )

--- a/tests/ui/test_status_label_color.py
+++ b/tests/ui/test_status_label_color.py
@@ -1,0 +1,23 @@
+import re
+
+from mutants2.engine.player import Player
+from mutants2.ui.render import render_status
+from mutants2.ui.theme import COLOR_ITEM
+
+
+def strip(s: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", s)
+
+
+def test_status_labels_use_item_color():
+    p = Player(year=2000, clazz="Warrior")
+    lines = render_status(p)
+    rib_line = [ln for ln in lines if "Riblets" in ln][0]
+    rib_label = COLOR_ITEM("Riblets      :")
+    assert rib_line.startswith(rib_label)
+    assert "\x1b[" not in rib_line.replace(rib_label, "")
+
+    ion_line = [ln for ln in lines if "Ions" in ln][0]
+    ion_label = COLOR_ITEM("Ions         :")
+    assert ion_line.startswith(ion_label)
+    assert "\x1b[" not in ion_line.replace(ion_label, "")


### PR DESCRIPTION
## Summary
- introduce COLOR_HEADER and COLOR_ITEM palette constants and apply them to exits, ground items and stats labels
- collapse kill rewards to a single collect line and add crumble notice after drops
- document new color usage and test exit palette, stats labels and loot flow

## Testing
- `black mutants2/ui/render.py tests/smoke/test_render_enumeration_and_wrap.py tests/ui/test_status_label_color.py tests/ui/test_loot_flow.py tests/ui/test_exits_color_split.py tests/smoke/test_look_inventory_only_and_exits_spacing.py tests/ui/test_kill_reward_color.py tests/smoke/test_equip_render_rewards.py`
- `ruff check .`
- `pyright mutants2`
- `vulture mutants2`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf05fe3548832bb7d9591a41be217c