### PR TITLE
Ensure skull drops on monster death with correct message order

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -15,7 +15,7 @@ This document defines the contracts our agents (and humans) must follow.
 - **item color** — Ground item names and exit description segments after the en-dash (e.g., `area continues.`).
 - **yellow** — Generic feedback & help; prompts; “lovely” look-for-item line; inventory-scope failures (`You can't see <raw_subject>.`, `You're not carrying <raw_subject>.`); shadows header.
 - **white** — Class selection menu; inventory list body; monster names shown in room renders (from look or `look <dir>`); monster taunts/native attacks (e.g., `Critter-750 bites you!`).
-- **red** — Room header/description; ion conversion feedback; kill & loot/rewards; monster arrival/leave; “crumbling to dust” after loot; weapon/armor crack; ranged “blinding flash”; monster spell preamble; spell damage descriptions; monster picks up an item; monster converts an item to ions; monster drops an item.
+- **red** — Room header/description; kill/collect/drop/crumble lines; ion conversion feedback; monster arrival/leave; weapon/armor crack; ranged “blinding flash”; monster spell preamble; spell damage descriptions; monster picks up an item; monster converts an item to ions; monster drops an item.
 
 Numbers are always plain (no commas).
 
@@ -48,8 +48,11 @@ Numbers are always plain (no commas).
 ## Monsters, targeting, and rewards
 - Multiple monsters can share a tile; names include a **unique 4-digit suffix** (e.g., `Mutant-1846`).
 - **`combat <monster>`** selects a target (consumes a turn) and prints **“You’re ready to combat <Name>!”**; legacy `attack` is removed.
-- Wielding hits only if **ready to combat** someone.  
+- Wielding hits only if **ready to combat** someone.
 - On kill: award **20000 riblets** and **20000 ions**.
+
+## Loot rules
+- Every monster drops a Skull on death (placed on ground and announced).
 
 ## Inventory vs worn vs wield
 - **Worn items are not inventory:** `drop/convert/wield/wear` **exclude worn**; only **`remove`** acts on worn.

--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -516,7 +516,7 @@ def make_context(p, w, save, *, dev: bool = False):
         print(generic_fb("***"))
         print(generic_fb(f"You wield the {display_item_name_plain(inst, idef)}."))
         key = inst["key"]
-        dmg, killed, name_mon = combat.player_attack(p, w, key)
+        dmg, killed, name_mon = combat.player_attack(context, key)
         print(generic_fb("***"))
         print(generic_fb(f"You hit {name_mon} for {dmg} damage.  (temp)"))
         context._needs_render = False

--- a/mutants2/engine/combat.py
+++ b/mutants2/engine/combat.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 import math
 
+from types import SimpleNamespace
+
 from .leveling import check_level_up
-from . import items as items_mod
+from . import items as items_mod, monsters as monsters_mod
+from .items_util import coerce_item
+from ..ui.items_render import display_item_name_plain
+from ..engine.items_resolver import get_item_def_by_key
+from ..ui.articles import article_for
 from ..data.config import AC_DIVISOR
 from ..ui.render import render_kill_block
 from ..ui.theme import SEP
@@ -25,31 +31,56 @@ def award_kill(player) -> int:
     return MONSTER_XP
 
 
-def player_attack(player, world, weapon_key: str):
+def handle_monster_death(ctx: SimpleNamespace, mon) -> None:
+    """Handle XP, loot drops, and crumble messaging for a slain monster."""
+
+    p = ctx.player
+    w = ctx.world
+
+    ions = 20_000
+    riblets = 20_000
+    p.ions += ions
+    p.riblets += riblets
+    award_kill(p)
+    render_kill_block(riblets, ions)
+
+    drops = [coerce_item(d) for d in mon.get("gear", [])]
+    mdef = monsters_mod.REGISTRY.get(mon.get("key"))
+    mtype = mdef.name if mdef else "Unknown"
+    drops.append({"key": "skull", "monster_type": mtype})
+    name = str(mon.get("name", ""))
+    for inst in drops:
+        w.add_ground_item(p.year, p.x, p.y, inst)
+        idef = get_item_def_by_key(inst["key"])
+        iname = display_item_name_plain(inst, idef)
+        art = article_for(iname)
+        print(kill_reward(f"{art} {iname} is falling from {name}'s body!"))
+
+    print(SEP)
+    print(kill_reward(f"{name} is crumbling to dust!"))
+
+
+def player_attack(ctx: SimpleNamespace, weapon_key: str):
     """Perform a single attack against the first monster here.
 
     Returns ``(damage, killed, name)`` where ``name`` is the monster's name.
     """
 
-    mon = world.monster_here(player.year, player.x, player.y)
+    p = ctx.player
+    w = ctx.world
+
+    mon = w.monster_here(p.year, p.x, p.y)
     if not mon:
         return 0, False, ""
     item = items_mod.REGISTRY.get(weapon_key)
     base = item.base_power if item else 0
-    str_bonus = player.strength // 10
+    str_bonus = p.strength // 10
     defender_ac = int(mon.get("ac_total", 0))
     ac_red = math.floor(defender_ac / AC_DIVISOR)
     raw = base + str_bonus - ac_red
     dmg = max(1, raw)
     name = str(mon.get("name", ""))
-    killed = world.damage_monster(player.year, player.x, player.y, dmg, player)
+    killed = w.damage_monster(p.year, p.x, p.y, dmg, p)
     if killed:
-        ions = 20_000
-        riblets = 20_000
-        player.ions += ions
-        player.riblets += riblets
-        award_kill(player)
-        render_kill_block(riblets, ions)
-        print(SEP)
-        print(kill_reward(f"{name} is crumbling to dust!"))
+        handle_monster_death(ctx, mon)
     return dmg, killed, name

--- a/tests/smoke/test_equip_render_rewards.py
+++ b/tests/smoke/test_equip_render_rewards.py
@@ -71,6 +71,7 @@ def test_kill_rewards():
         ["get light", "combat mutant", "wield light", "status"], setup=setup
     )
     assert "You collect 20000 Riblets and 20000 ions from the slain body." in out
+    assert re.search(r"A Skull is falling from Mutant-\d{4}'s body!", out)
     assert re.search(r"\*\*\*\nMutant-\d{4} is crumbling to dust!", out)
     assert "You gain" not in out
     assert p.riblets == 20000 and p.ions == 20000

--- a/tests/smoke/test_skull_drop_and_order.py
+++ b/tests/smoke/test_skull_drop_and_order.py
@@ -1,0 +1,58 @@
+import contextlib
+import io
+import re
+import tempfile
+from pathlib import Path
+
+from mutants2.engine import persistence
+from mutants2.engine.world import World
+from mutants2.engine.player import Player
+from mutants2.cli.shell import make_context
+from mutants2.ui.theme import red, SEP
+
+
+def run_commands(cmds, setup=None):
+    save = persistence.Save()
+    w = World()
+    w.year(2000)
+    p = Player(year=2000, clazz="Warrior")
+    if setup:
+        setup(w, p)
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    orig = persistence.SAVE_PATH
+    with tempfile.TemporaryDirectory() as tmp:
+        persistence.SAVE_PATH = Path(tmp) / "save.json"
+        with contextlib.redirect_stdout(buf):
+            for c in cmds:
+                ctx.dispatch_line(c)
+    persistence.SAVE_PATH = orig
+    return buf.getvalue()
+
+
+def test_skull_drop_and_order():
+    def setup(w, p):
+        w.add_ground_item(2000, 0, 0, {"key": "light_spear"})
+        w.place_monster(2000, 0, 0, "mutant")
+
+    out = run_commands(
+        ["get light", "combat mutant", "wield light", "get skull", "inventory"],
+        setup=setup,
+    )
+
+    collect = red("You collect 20000 Riblets and 20000 ions from the slain body.")
+    assert collect in out
+    drop_match = re.search(
+        r"\x1b\[31mA Skull is falling from Mutant-\d{4}'s body!\x1b\[0m",
+        out,
+    )
+    assert drop_match
+    assert out.find(collect) < drop_match.start()
+    crumble_match = re.search(
+        rf"{re.escape(SEP)}\n\x1b\[31mMutant-\d{{4}} is crumbling to dust!\x1b\[0m",
+        out,
+    )
+    assert crumble_match
+    assert drop_match.end() < crumble_match.start()
+    assert "You pick up A Skull." in out
+    assert "Skull." in out

--- a/tests/ui/test_loot_flow.py
+++ b/tests/ui/test_loot_flow.py
@@ -1,11 +1,12 @@
 import contextlib
 import io
 import re
+from types import SimpleNamespace
 
 from mutants2.engine.world import World
 from mutants2.engine.player import Player
 from mutants2.engine.combat import player_attack
-from mutants2.ui.theme import red
+from mutants2.ui.theme import red, SEP
 
 
 def test_loot_flow_single_line_and_crumble():
@@ -13,13 +14,17 @@ def test_loot_flow_single_line_and_crumble():
     w.year(2000)
     w.place_monster(2000, 0, 0, "mutant")
     p = Player(year=2000, clazz="Warrior")
+    ctx = SimpleNamespace(player=p, world=w)
     buf = io.StringIO()
     with contextlib.redirect_stdout(buf):
-        player_attack(p, w, "nuclear_rock")
+        player_attack(ctx, "nuclear_rock")
     out = buf.getvalue()
     assert red("You collect 20000 Riblets and 20000 ions from the slain body.") in out
+    assert re.search(
+        r"\x1b\[31mA Skull is falling from Mutant-\d{4}'s body!\x1b\[0m", out
+    )
     assert re.search(r"You gain \d+ riblets", out) is None
     assert re.search(
-        r"\x1b\[37m\*\*\*\x1b\[0m\n\x1b\[31mMutant-\d{4} is crumbling to dust!\x1b\[0m",
+        rf"\x1b\[31mA Skull is falling from Mutant-\d{{4}}'s body!\x1b\[0m\n{re.escape(SEP)}\n\x1b\[31mMutant-\d{{4}} is crumbling to dust!\x1b\[0m",
         out,
     )


### PR DESCRIPTION
## Summary
- Always drop a Skull when any monster dies and announce it before the crumble line
- Centralize death handling via `handle_monster_death`, preserving loot order and using article helper
- Document red kill/collect/drop/crumble lines and new mandatory Skull drop
- Add smoke test and adjust loot tests for guaranteed Skull drop

## Testing
- `black tests/smoke/test_skull_drop_and_order.py tests/ui/test_loot_flow.py tests/smoke/test_equip_render_rewards.py mutants2/engine/combat.py mutants2/cli/shell.py`
- `ruff check .`
- `pyright` *(fails: Argument of type "dict[str, str]" cannot be assigned to parameter ...)*
- `vulture .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf26c510c4832b84c5de45692db063