### PR TITLE
Align stats inventory color with header and expand smoke tests

### DIFF
--- a/docs/agents.md
+++ b/docs/agents.md
@@ -11,8 +11,8 @@ This document defines the contracts our agents (and humans) must follow.
 
 ## Color palette & usage
 - **green** — Compass line (e.g., `Compass: (0E : 0N)`).
-- **header color** — Section titles like `On the ground lies:` and cardinal direction words (`north`, `south`, `east`, `west`).
-- **item color** — Ground item names and exit description segments after the en-dash (e.g., `area continues.`).
+- **header color** — Section titles like `On the ground lies:` and cardinal direction words (`north`, `south`, `east`, `west`); stats inventory header and inline list.
+- **item color** — Ground item names and exit description segments after the en-dash (e.g., `area continues.`); no lighter variant exists.
 - **yellow** — Generic feedback & help; prompts; “lovely” look-for-item line; inventory-scope failures (`You can't see <raw_subject>.`, `You're not carrying <raw_subject>.`); shadows header.
 - **white** — Class selection menu; inventory list body; monster names shown in room renders (from look or `look <dir>`); monster taunts/native attacks (e.g., `Critter-750 bites you!`).
 - **red** — Room header/description; kill/collect/drop/crumble lines; ion conversion feedback; monster arrival/leave; weapon/armor crack; ranged “blinding flash”; monster spell preamble; spell damage descriptions; monster picks up an item; monster converts an item to ions; monster drops an item.

--- a/mutants2/cli/shell.py
+++ b/mutants2/cli/shell.py
@@ -713,7 +713,7 @@ def make_context(p, w, save, *, dev: bool = False):
         if names:
             labels = enumerate_duplicates(names)
             wrapped = wrap_list_ansi(labels)
-            lines.extend(white(ln) for ln in wrapped.splitlines())
+            lines.extend(generic_fb(ln) for ln in wrapped.splitlines())
         for ln in lines:
             print(ln)
 

--- a/mutants2/ui/theme.py
+++ b/mutants2/ui/theme.py
@@ -21,6 +21,10 @@ def white(s: str) -> str:
     return s if NO_COLOR else f"\x1b[37m{s}\x1b[0m"
 
 
+# Core semantic colors -------------------------------------------------------
+# ``COLOR_HEADER`` drives section titles such as "On the ground lies:",
+# cardinal direction labels, and the stats inventory header/list.  ``COLOR_ITEM``
+# is used for ground item names and exit descriptions.
 COLOR_HEADER = yellow
 COLOR_ITEM = cyan
 
@@ -30,3 +34,16 @@ COLOR_ITEM = cyan
 blue = cyan
 
 SEP = white("***")
+
+__all__ = [
+    "NO_COLOR",
+    "green",
+    "cyan",
+    "yellow",
+    "red",
+    "white",
+    "COLOR_HEADER",
+    "COLOR_ITEM",
+    "blue",
+    "SEP",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+"""Test configuration and path setup."""
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/smoke/test_compass_and_exits_colors.py
+++ b/tests/smoke/test_compass_and_exits_colors.py
@@ -1,8 +1,0 @@
-from mutants2.testing_api import run_one
-
-
-def test_compass_and_exits_colors():
-    out = run_one("look")
-    assert "Compass: (0E : 0N)" in out
-    assert "north – area continues." in out
-    assert "south – area continues." in out

--- a/tests/smoke/test_room_colors_smoke.py
+++ b/tests/smoke/test_room_colors_smoke.py
@@ -1,0 +1,49 @@
+import contextlib
+import io
+import re
+import tempfile
+from pathlib import Path
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import world as world_mod, persistence
+from mutants2.engine.player import Player
+from mutants2.ui.render import render_single_exit
+from mutants2.ui.theme import COLOR_HEADER, COLOR_ITEM, green, red
+
+
+def run_look() -> list[str]:
+    save = persistence.Save(global_seed=42)
+    w = world_mod.World(global_seed=42)
+    w.year(2000)
+    w.set_ground_item(2000, 0, 0, "skull")
+    p = Player(year=2000, clazz="Warrior", ions=100000)
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with tempfile.TemporaryDirectory() as tmp:
+        persistence.SAVE_PATH = Path(tmp) / "save.json"
+        with contextlib.redirect_stdout(buf):
+            ctx.dispatch_line("look")
+    return buf.getvalue().splitlines()
+
+
+ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def strip(s: str) -> str:
+    return ANSI_RE.sub("", s)
+
+
+def test_room_colors_smoke() -> None:
+    lines = run_look()
+    # 0 = command echo; 1 = header; 2 = compass
+    assert lines[1] == red(strip(lines[1]))
+    assert lines[2] == green("Compass: (0E : 0N)")
+
+    exits = [
+        render_single_exit(d, "area continues.")
+        for d in ("north", "south", "east", "west")
+    ]
+    assert lines[3:7] == exits
+
+    assert lines[7] == COLOR_HEADER("On the ground lies:")
+    assert lines[8] == COLOR_ITEM("A Skull.")

--- a/tests/smoke/test_stats_inventory_color.py
+++ b/tests/smoke/test_stats_inventory_color.py
@@ -1,0 +1,38 @@
+import contextlib
+import io
+import tempfile
+from pathlib import Path
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import world as world_mod, persistence
+from mutants2.engine.player import Player
+from mutants2.ui.theme import COLOR_HEADER, COLOR_ITEM
+
+
+def run_status() -> list[str]:
+    save = persistence.Save(global_seed=42)
+    w = world_mod.World(global_seed=42)
+    w.year(2000)
+    inventory = [{"key": "skull"}, {"key": "ion_pack"}]
+    p = Player(year=2000, clazz="Warrior", ions=100000, inventory=inventory)
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with tempfile.TemporaryDirectory() as tmp:
+        persistence.SAVE_PATH = Path(tmp) / "save.json"
+        with contextlib.redirect_stdout(buf):
+            ctx.dispatch_line("status")
+    return buf.getvalue().splitlines()
+
+
+def test_stats_inventory_color() -> None:
+    lines = run_status()
+    header = COLOR_HEADER(
+        "You are carrying the following items:  (Total Weight: 55 LB's)"
+    )
+    idx = lines.index(header)
+    assert lines[idx + 1] == COLOR_HEADER("Skull, Ion-Pack.")
+
+    ion_line = next(ln for ln in lines if "Ions" in ln)
+    label = COLOR_ITEM("Ions         :")
+    assert ion_line.startswith(label)
+    assert "\x1b[" not in ion_line.replace(label, "")

--- a/tests/smoke/test_travel_feedback.py
+++ b/tests/smoke/test_travel_feedback.py
@@ -1,7 +1,0 @@
-from mutants2.testing_api import run_one
-
-
-def test_travel_feedback():
-    out = run_one("travel 2100")
-    assert "ZAAAAPPPPP!! You've been sent to the year 2100 A.D." in out
-    assert "Compass:" not in out

--- a/tests/smoke/test_travel_feedback_smoke.py
+++ b/tests/smoke/test_travel_feedback_smoke.py
@@ -1,0 +1,31 @@
+import contextlib
+import io
+import tempfile
+from pathlib import Path
+
+from mutants2.cli.shell import make_context
+from mutants2.engine import world as world_mod, persistence
+from mutants2.engine.player import Player
+from mutants2.ui.theme import COLOR_HEADER
+
+
+def run_travel() -> list[str]:
+    save = persistence.Save(global_seed=42)
+    w = world_mod.World(global_seed=42)
+    w.year(2000)
+    p = Player(year=2000, clazz="Warrior", ions=100000)
+    ctx = make_context(p, w, save)
+    buf = io.StringIO()
+    with tempfile.TemporaryDirectory() as tmp:
+        persistence.SAVE_PATH = Path(tmp) / "save.json"
+        with contextlib.redirect_stdout(buf):
+            ctx.dispatch_line("travel 2342")
+    return buf.getvalue().splitlines()
+
+
+def test_travel_feedback_smoke() -> None:
+    lines = run_travel()
+    assert lines[1] == COLOR_HEADER(
+        "ZAAAAPPPPP!! You've been sent to the year 2300 A.D."
+    )
+    assert all("Compass:" not in ln for ln in lines[2:])


### PR DESCRIPTION
## Summary
- Ensure stats page inline inventory list uses header color
- Document color roles and export semantic color constants
- Add smoke tests for stats inventory, room render colors, and travel feedback

## Testing
- `black .`
- `ruff check .`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf75d268bc832bb489858dbf6f17fc